### PR TITLE
Update __init__.py to allow multiple sentences

### DIFF
--- a/conllu/__init__.py
+++ b/conllu/__init__.py
@@ -6,7 +6,7 @@ from conllu.parser import head_to_token, parse_token_and_metadata
 
 def parse(data, fields=None):
     return [
-        TokenList(*parse_token_and_metadata(data, fields=fields))
+        TokenList(*parse_token_and_metadata(sentence, fields=fields))
         for sentence in data.split("\n\n")
         if sentence
     ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import unittest
 from textwrap import dedent
 
-from conllu import parse, parse_tree
+from conllu import parse
 from conllu.compat import text
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import unittest
+from textwrap import dedent
+
+from conllu import parse, parse_tree
+from conllu.compat import text
+
+
+class TestParse(unittest.TestCase):
+    def test_multiple_sentences(self):
+        data = dedent("""\
+            1   The     the    DET    DT   Definite=Def|PronType=Art   4   det     _   _
+            2   dog     dog    NOUN   NN   Number=Sing                 5   nmod    _   SpaceAfter=No
+            3  .       .      PUNCT  .    _                           5   punct   _   _
+
+            1   The     the    DET    DT   Definite=Def|PronType=Art   4   det     _   _
+            2   dog     dog    NOUN   NN   Number=Sing                 5   nmod    _   SpaceAfter=No
+            3  .       .      PUNCT  .    _                           5   punct   _   _
+
+        """)
+        self.assertEqual(
+            text(parse(data)),
+            "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+        )


### PR DESCRIPTION
Fix a bug in the case that data contains multiple sentences.
Previous behavior was to treat the multiple sentences as one very long sentence.