### PR TITLE
Add incremental parsing and add back public list -> tree conversion

### DIFF
--- a/conllu/__init__.py
+++ b/conllu/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from conllu.models import TokenList, TokenTree
-from conllu.parser import head_to_token, parse_token_and_metadata
+from conllu.models import TokenList
+from conllu.parser import parse_token_and_metadata
 
 
 def parse(data, fields=None):
@@ -14,16 +14,8 @@ def parse(data, fields=None):
 def parse_tree(data):
     tokenlists = parse(data)
 
-    def _create_tree(head_to_token_mapping, id_=0):
-        return [
-            TokenTree(child, _create_tree(head_to_token_mapping, child["id"]))
-            for child in head_to_token_mapping[id_]
-        ]
-
     sentences = []
     for tokenlist in tokenlists:
-        root = _create_tree(head_to_token(tokenlist))[0]
-        root.set_metadata(tokenlist.metadata)
-        sentences.append(root)
+        sentences.append(tokenlist.to_tree())
 
     return sentences

--- a/conllu/__init__.py
+++ b/conllu/__init__.py
@@ -11,6 +11,24 @@ def parse(data, fields=None):
         if sentence
     ]
 
+
+def _iter_sents(in_file):
+    buf = []
+    for line in in_file:
+        if line == "\n":
+            yield "".join(buf)[:-1]
+            buf = []
+        else:
+            buf.append(line)
+    if buf:
+        yield "".join(buf)
+
+
+def parse_incr(in_file, fields=None):
+    for sentence in _iter_sents(in_file):
+        yield TokenList(*parse_token_and_metadata(sentence, fields=fields))
+
+
 def parse_tree(data):
     tokenlists = parse(data)
 
@@ -19,3 +37,8 @@ def parse_tree(data):
         sentences.append(tokenlist.to_tree())
 
     return sentences
+
+
+def parse_tree_incr(in_file):
+    for tokenlist in parse_incr(in_file):
+        yield tokenlist.to_tree()

--- a/conllu/__init__.py
+++ b/conllu/__init__.py
@@ -11,6 +11,22 @@ def parse(data, fields=None):
         if sentence
     ]
 
+def parse_incr(in_file, fields=None):
+    for sentence in _iter_sents(in_file):
+        yield TokenList(*parse_token_and_metadata(sentence, fields=fields))
+
+def parse_tree(data):
+    tokenlists = parse(data)
+
+    sentences = []
+    for tokenlist in tokenlists:
+        sentences.append(tokenlist.to_tree())
+
+    return sentences
+
+def parse_tree_incr(in_file):
+    for tokenlist in parse_incr(in_file):
+        yield tokenlist.to_tree()
 
 def _iter_sents(in_file):
     buf = []
@@ -22,23 +38,3 @@ def _iter_sents(in_file):
             buf.append(line)
     if buf:
         yield "".join(buf)
-
-
-def parse_incr(in_file, fields=None):
-    for sentence in _iter_sents(in_file):
-        yield TokenList(*parse_token_and_metadata(sentence, fields=fields))
-
-
-def parse_tree(data):
-    tokenlists = parse(data)
-
-    sentences = []
-    for tokenlist in tokenlists:
-        sentences.append(tokenlist.to_tree())
-
-    return sentences
-
-
-def parse_tree_incr(in_file):
-    for tokenlist in parse_incr(in_file):
-        yield tokenlist.to_tree()

--- a/conllu/models.py
+++ b/conllu/models.py
@@ -22,6 +22,9 @@ class TokenList(object):
     def __repr__(self):
         return 'TokenList<' + ', '.join([token['form'] for token in self.tokens]) + '>'
 
+    def __eq__(self, other):
+        return self.tokens == other.tokens and self.metadata == other.metadata
+
     def serialize(self):
         return serialize(self)
 
@@ -54,6 +57,10 @@ class TokenTree(object):
             'token={id=' + text(self.token['id']) + ', form=' + self.token['form'] + '}, ' + \
             'children=' + ('[...]' if self.children else 'None') + \
             '>'
+
+    def __eq__(self, other):
+        return self.token == other.token and self.children == other.children \
+            and self.metadata == other.metadata
 
     def serialize(self):
         if not self.token or "id" not in self.token:

--- a/conllu/models.py
+++ b/conllu/models.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, unicode_literals
 
 from conllu.compat import text
-from conllu.parser import ParseException, serialize
+from conllu.parser import ParseException, head_to_token, serialize
 
 DEFAULT_EXCLUDE_FIELDS = ('id', 'deprel', 'xpostag', 'feats', 'head', 'deps', 'misc')
 
@@ -24,6 +24,17 @@ class TokenList(object):
 
     def serialize(self):
         return serialize(self)
+
+    def to_tree(self):
+        def _create_tree(head_to_token_mapping, id_=0):
+            return [
+                TokenTree(child, _create_tree(head_to_token_mapping, child["id"]))
+                for child in head_to_token_mapping[id_]
+            ]
+
+        root = _create_tree(head_to_token(self))[0]
+        root.set_metadata(self.metadata)
+        return root
 
 class TokenTree(object):
     token = None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,9 +4,10 @@ from __future__ import unicode_literals
 import re
 import unittest
 from collections import OrderedDict
+from io import StringIO
 from textwrap import dedent
 
-from conllu import parse, parse_tree
+from conllu import parse, parse_incr, parse_tree, parse_tree_incr
 from conllu.compat import capture_print, text
 from tests.helpers import testlabel
 
@@ -143,6 +144,12 @@ class TestParse(unittest.TestCase):
         toklists = parse(data)
         tree = parse_tree(data)
         self.assertEqual([toklist.to_tree() for toklist in toklists], tree)
+
+    def test_parse_incr(self):
+        self.assertEqual(parse(data), list(parse_incr(StringIO(data))))
+
+    def test_parse_tree_incr(self):
+        self.assertEqual(parse_tree(data), list(parse_tree_incr(StringIO(data))))
 
 
 @testlabel("integration")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -139,6 +139,12 @@ class TestParse(unittest.TestCase):
             """)
         )
 
+    def test_to_tree(self):
+        toklists = parse(data)
+        tree = parse_tree(data)
+        self.assertEqual([toklist.to_tree() for toklist in toklists], tree)
+
+
 @testlabel("integration")
 class TestTrickyCases(unittest.TestCase):
     maxDiff = None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -140,11 +140,6 @@ class TestParse(unittest.TestCase):
             """)
         )
 
-    def test_to_tree(self):
-        toklists = parse(data)
-        tree = parse_tree(data)
-        self.assertEqual([toklist.to_tree() for toklist in toklists], tree)
-
     def test_parse_incr(self):
         self.assertEqual(parse(data), list(parse_incr(StringIO(data))))
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,20 @@ class TestTokenList(unittest.TestCase):
         tokenlist2.metadata = metadata
         self.assertEqual(tokenlist1, tokenlist2)
 
+    def test_to_tree(self):
+        tokenlist = TokenList([
+            OrderedDict([("id", 2), ("form", "dog"), ("head", 0)]),
+            OrderedDict([("id", 1), ("form", "a"), ("head", 2)]),
+        ])
+        tree = TokenTree(
+            token=OrderedDict([("id", 2), ("form", "dog"), ("head", 0)]),
+            children=[TokenTree(
+                token=OrderedDict([("id", 1), ("form", "a"), ("head", 2)]),
+                children=[]
+            )]
+        )
+        self.assertEqual(tokenlist.to_tree(), tree)
+
 class TestSerialize(unittest.TestCase):
     def test_serialize_on_tokenlist(self):
         tokenlist = TokenList([{"id": 1}])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,12 +15,38 @@ class TestTokenList(unittest.TestCase):
         with self.assertRaises(ParseException):
             TokenList({"id": 1})
 
+    def test_eq(self):
+        metadata = {"meta": "data"}
+
+        tokenlist1 = TokenList([{"id": 1}])
+        tokenlist1.metadata = metadata
+        tokenlist2 = TokenList([{"id": 1}])
+        self.assertNotEqual(tokenlist1, tokenlist2)
+
+        tokenlist2.metadata = metadata
+        self.assertEqual(tokenlist1, tokenlist2)
+
 class TestSerialize(unittest.TestCase):
     def test_serialize_on_tokenlist(self):
         tokenlist = TokenList([{"id": 1}])
         self.assertEqual(tokenlist.serialize(), serialize(tokenlist))
 
 class TestTokenTree(unittest.TestCase):
+    def test_eq(self):
+        metadata = {"meta": "data"}
+
+        tokentree1 = TokenTree(token={"id": 1}, children=[TokenTree(token={"id": 2}, children=[])])
+        tokentree1.metadata = metadata
+
+        tokentree2 = TokenTree(token={"id": 1}, children=[])
+        self.assertNotEqual(tokentree1, tokentree2)
+
+        tokentree2.metadata = metadata
+        self.assertNotEqual(tokentree1, tokentree2)
+
+        tokentree2.children = [TokenTree(token={"id": 2}, children=[])]
+        self.assertEqual(tokentree1, tokentree2)
+
     def test_metadata(self):
         tree = TokenTree(token={"id": 1, "form": "hej"}, children=[])
         metadata = {"meta": "data"}


### PR DESCRIPTION
This PR allows incremental parsing from file/streams as suggested in https://github.com/EmilStenstrom/conllu/pull/2 . It also adds back the a way of doing a "flat -> tree" conversion back to the new API, as originally added in https://github.com/EmilStenstrom/conllu/pull/4 . 