### PR TITLE
Make TokenList inherit from list

### DIFF
--- a/conllu/models.py
+++ b/conllu/models.py
@@ -26,9 +26,6 @@ class TokenList(list):
     def __ne__(self, other):
         return not self == other
 
-    def __sizeof__(self):
-        return super(TokenList, self).__sizeof__() + getattr(self.metadata, '__sizeof__', lambda: 0)()
-
     def clear(self):
         self[:] = []  # Supported in Python 2 and 3, unlike clear()
         self.metadata = None

--- a/conllu/models.py
+++ b/conllu/models.py
@@ -5,25 +5,56 @@ from conllu.parser import ParseException, head_to_token, serialize
 
 DEFAULT_EXCLUDE_FIELDS = ('id', 'deprel', 'xpostag', 'feats', 'head', 'deps', 'misc')
 
-class TokenList(object):
-    tokens = None
+
+class TokenList(list):
     metadata = None
 
     def __init__(self, tokens, metadata=None):
+        super(TokenList, self).__init__(tokens)
         if not isinstance(tokens, list):
             raise ParseException("Can't create TokenList, tokens is not a list.")
 
-        self.tokens = tokens
         self.metadata = metadata
 
-    def __getitem__(self, key):
-        return self.tokens[key]
-
     def __repr__(self):
-        return 'TokenList<' + ', '.join([token['form'] for token in self.tokens]) + '>'
+        return 'TokenList<' + ', '.join(token['form'] for token in self) + '>'
 
     def __eq__(self, other):
-        return self.tokens == other.tokens and self.metadata == other.metadata
+        return super(TokenList, self).__eq__(other) \
+               and (not hasattr(other, 'metadata') or self.metadata == other.metadata)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __sizeof__(self):
+        return super(TokenList, self).__sizeof__() + getattr(self.metadata, '__sizeof__', lambda: 0)()
+
+    def clear(self):
+        self[:] = []  # Supported in Python 2 and 3, unlike clear()
+        self.metadata = None
+
+    def copy(self):
+        tokens_copy = self[:]  # Supported in Python 2 and 3, unlike copy()
+        return TokenList(tokens_copy, self.metadata)
+
+    def extend(self, iterable):
+        super(TokenList, self).extend(iterable)
+        if hasattr(iterable, 'metadata'):
+            if hasattr(self.metadata, '__add__') and hasattr(iterable.metadata, '__add__'):
+                self.metadata += iterable.metadata
+            elif type(self.metadata) is dict and type(iterable.metadata) is dict:
+                # noinspection PyUnresolvedReferences
+                self.metadata.update(iterable.metadata)
+            else:
+                self.metadata = [self.metadata, iterable.metadata]
+
+    @property
+    def tokens(self):
+        return self
+
+    @tokens.setter
+    def tokens(self, value):
+        self[:] = value  # Supported in Python 2 and 3, unlike clear()
 
     def serialize(self):
         return serialize(self)
@@ -38,6 +69,7 @@ class TokenList(object):
         root = _create_tree(head_to_token(self))[0]
         root.set_metadata(self.metadata)
         return root
+
 
 class TokenTree(object):
     token = None

--- a/conllu/models.py
+++ b/conllu/models.py
@@ -21,7 +21,7 @@ class TokenList(list):
 
     def __eq__(self, other):
         return super(TokenList, self).__eq__(other) \
-               and (not hasattr(other, 'metadata') or self.metadata == other.metadata)
+            and (not hasattr(other, 'metadata') or self.metadata == other.metadata)
 
     def __ne__(self, other):
         return not self == other

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import sys
 import unittest
 from collections import OrderedDict
 from textwrap import dedent
@@ -30,13 +29,6 @@ class TestTokenList(unittest.TestCase):
     def test_len(self):
         tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
         self.assertEqual(3, len(tokenlist))
-
-    def test_sizeof(self):
-        tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
-        self.assertGreater(sys.getsizeof(tokenlist1), sys.getsizeof([{"id": 1}, {"id": 2}, {"id": 3}]))
-
-        tokenlist2 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
-        self.assertLess(sys.getsizeof(tokenlist1), sys.getsizeof(tokenlist2))
 
     def test_clear(self):
         tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import sys
 import unittest
 from collections import OrderedDict
 from textwrap import dedent
@@ -26,6 +27,62 @@ class TestTokenList(unittest.TestCase):
         tokenlist2.metadata = metadata
         self.assertEqual(tokenlist1, tokenlist2)
 
+    def test_len(self):
+        tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
+        self.assertEqual(3, len(tokenlist))
+
+    def test_sizeof(self):
+        tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
+        self.assertGreater(sys.getsizeof(tokenlist1), sys.getsizeof([{"id": 1}, {"id": 2}, {"id": 3}]))
+
+        tokenlist2 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
+        self.assertLess(sys.getsizeof(tokenlist1), sys.getsizeof(tokenlist2))
+
+    def test_clear(self):
+        tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
+        tokenlist.clear()
+        self.assertEqual(len(tokenlist.tokens), 0)
+        self.assertEqual(tokenlist.metadata, None)
+
+    def test_copy(self):
+        tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
+        tokenlist2 = tokenlist1.copy()
+        self.assertIsNot(tokenlist1, tokenlist2)
+        self.assertEqual(tokenlist1, tokenlist2)
+
+    def test_extend(self):
+        tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
+        tokenlist2 = [{"id": 4}, {"id": 5}, {"id": 6}]
+        tokenlist1.extend(tokenlist2)
+        tokenlist3 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}])
+        self.assertEqual(tokenlist1, tokenlist3)
+
+        tokenlist4 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta1": "data1"})
+        tokenlist5 = TokenList([{"id": 4}, {"id": 5}, {"id": 6}], {"meta2": "data2"})
+        tokenlist4.extend(tokenlist5)
+        tokenlist6 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}],
+                               {"meta1": "data1", "meta2": "data2"})
+        self.assertEqual(tokenlist4, tokenlist6)
+
+        tokenlist7 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], "abc")
+        tokenlist8 = TokenList([{"id": 4}, {"id": 5}, {"id": 6}], "de")
+        tokenlist7.extend(tokenlist8)
+        tokenlist9 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}], "abcde")
+        self.assertEqual(tokenlist7, tokenlist9)
+
+        tokenlist7 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], "abc")
+        tokenlist8 = TokenList([{"id": 4}, {"id": 5}, {"id": 6}], {"meta2": "data2"})
+        tokenlist7.extend(tokenlist8)
+        tokenlist9 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}],
+                               ["abc", {"meta2": "data2"}])
+        self.assertEqual(tokenlist7, tokenlist9)
+
+    def test_tokens(self):
+        tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
+        self.assertEqual(tokenlist.tokens, [{"id": 1}, {"id": 2}, {"id": 3}])
+        tokenlist.tokens = [{"id": 4}, {"id": 5}]
+        self.assertEqual(tokenlist.tokens, [{"id": 4}, {"id": 5}])
+
     def test_to_tree(self):
         tokenlist = TokenList([
             OrderedDict([("id", 2), ("form", "dog"), ("head", 0)]),
@@ -40,10 +97,12 @@ class TestTokenList(unittest.TestCase):
         )
         self.assertEqual(tokenlist.to_tree(), tree)
 
+
 class TestSerialize(unittest.TestCase):
     def test_serialize_on_tokenlist(self):
         tokenlist = TokenList([{"id": 1}])
         self.assertEqual(tokenlist.serialize(), serialize(tokenlist))
+
 
 class TestTokenTree(unittest.TestCase):
     def test_eq(self):
@@ -66,6 +125,7 @@ class TestTokenTree(unittest.TestCase):
         metadata = {"meta": "data"}
         tree.set_metadata(metadata)
         self.assertEqual(tree.metadata, metadata)
+
 
 class TestSerializeTree(unittest.TestCase):
     def test_missing_id(self):
@@ -104,6 +164,7 @@ class TestSerializeTree(unittest.TestCase):
 
             """)
         )
+
 
 class TestPrintTree(unittest.TestCase):
     def test_print_empty_list(self):


### PR DESCRIPTION
Make `TokenList` inherit from `list`. acquiring its behavior: len, not eq, sizeof, clear, copy, extend, append, count, index, insert, pop, remove, reverse, sort, add, in, comparisons and multiply.

This is supposed to be a non-breaking change. There are properties to still access the `tokens` variable as before.

I also removed an unnecessary list comprehension, I turned it into a generator expression (it saves memory, as it's iterated in-place).

Fixes #18

NB: I made comparisons (<, <=, >, >=) to directly inherit from `list` and not involving `metadata`. This is because it could be cumbersome: both objects could have different types of metadata, even the RHS may not have it (e.g. it's a simple list), and they may not be comparable. To avoid a creating artificial relation, I just inherit it, not using the metadata then.