### PR TITLE
Fix inconsistency with format specification for IDs

### DIFF
--- a/conllu/parser.py
+++ b/conllu/parser.py
@@ -99,7 +99,7 @@ def parse_int_value(value):
 
 ID_SINGLE = re.compile(r"^[1-9][0-9]*$")
 ID_RANGE = re.compile(r"^[1-9][0-9]*\-[1-9][0-9]*$")
-ID_DOT_ID = re.compile(r"^[1-9][0-9]*\.[1-9][0-9]*$")
+ID_DOT_ID = re.compile(r"^[0-9][0-9]*\.[1-9][0-9]*$")
 
 def parse_id_value(value):
     if not value or value == '_':

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -154,12 +154,12 @@ class TestParseIDValue(unittest.TestCase):
 
     def test_decimal(self):
         self._run_valid_invalid_tests([
+            ("0.1", (0, ".", 1)),
             ("1.1", (1, ".", 1)),
             ("1.10", (1, ".", 10)),
             ("10.1", (10, ".", 1)),
         ], [
             "1.0",
-            "0.1",
             "a.0",
             "0.a",
         ])


### PR DESCRIPTION
IDs starting with 0 are considered invalid although, they are allowed by the specification. The standard clearly specifies that IDs can start with 0:  "To accommodate the use of empty nodes for the analysis of ellipsis in the enhanced dependency representation, we adopt a further extension of the indexing scheme from v2. It is possible to insert one or more empty nodes indexed i.1, i.2, etc. immediately after a word with index i (where i = 0 for sentence-initial empty nodes)." taken from http://universaldependencies.org/format.html#words-tokens-and-empty-nodes