### PR TITLE
added support for specific metadata fields with optional values

### DIFF
--- a/conllu/parser.py
+++ b/conllu/parser.py
@@ -75,12 +75,13 @@ def parse_comment_line(line):
     if line[0] != '#':
         raise ParseException("Invalid comment format, comment must start with '#'")
 
-    if '=' not in line:
+    stripped = line[1:].strip()
+    if '=' not in line and stripped != 'newdoc' and stripped != 'newpar':
         return None, None
 
-    var_name, var_value = line[1:].split('=', 1)
-    var_name = var_name.strip()
-    var_value = var_value.strip()
+    name_value = line[1:].split('=', 1)
+    var_name = name_value[0].strip()
+    var_value = None if len(name_value) == 1 else name_value[1].strip()
 
     return var_name, var_value
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -40,11 +40,13 @@ class TestParse(unittest.TestCase):
         data = dedent("""\
             # meta = data2
             # meta = data
+            # newdoc
+            # newpar
             # meta
             # = data
         """)
         _, metadata = parse_token_and_metadata(data)
-        self.assertEqual(metadata, OrderedDict([("meta", "data")]))
+        self.assertEqual(metadata, OrderedDict([("meta", "data"), ("newdoc", None), ("newpar", None)]))
 
 class TestParseLine(unittest.TestCase):
     def test_parse_line(self):
@@ -102,6 +104,15 @@ class TestParseCommentLine(unittest.TestCase):
     def test_parse_comment_line_without_equals(self):
         data = "# sent_id: 1"
         self.assertEqual(parse_comment_line(data), (None, None))
+
+    def test_parse_comment_line_optional_value(self):
+        data = '# newdoc'
+        self.assertEqual(parse_comment_line(data), ("newdoc", None))
+        data = '# newpar'
+        self.assertEqual(parse_comment_line(data), ("newpar", None))
+        data = '# invalid'
+        self.assertEqual(parse_comment_line(data), (None, None))
+
 
 class TestParseIntValue(unittest.TestCase):
     def test_parse_int_value(self):


### PR DESCRIPTION
As per the bottom of https://universaldependencies.org/format.html, in the Paragraph and Document Boundaries section, `newpar` and `newdoc` comments may be specified without an explicit id, e.g. `...paragraph contains a comment that says # newpar, which can be optionally followed by a paragraph id (newpar id = wsj2012-01-05-p1)...`

I allowed these two fields to be entered into the metadata dictionary with `None` values, with some tests.

Cheers on the great project
