### PR TITLE
Add support multi line between sentences

### DIFF
--- a/conllu/__init__.py
+++ b/conllu/__init__.py
@@ -32,6 +32,8 @@ def _iter_sents(in_file):
     buf = []
     for line in in_file:
         if line == "\n":
+            if not buf:
+                continue
             yield "".join(buf)[:-1]
             buf = []
         else:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,16 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import io
 import unittest
 from textwrap import dedent
 
-from conllu import parse
+from conllu import parse, parse_incr
 from conllu.compat import text
 
 
 class TestParse(unittest.TestCase):
+
     def test_multiple_sentences(self):
         data = dedent("""\
             1   The     the    DET    DT   Definite=Def|PronType=Art   4   det     _   _
@@ -20,7 +22,41 @@ class TestParse(unittest.TestCase):
             3  .       .      PUNCT  .    _                           5   punct   _   _
 
         """)
-        self.assertEqual(
-            text(parse(data)),
-            "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
-        )
+        with self.subTest("parse"):
+            self.assertEqual(
+                text(parse(data)),
+                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+            )
+
+        with self.subTest("parse_incr"):
+            self.assertEqual(
+                text([item for item in parse_incr(io.StringIO(data))]),
+                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+            )
+
+    def test_multi_empty_line_end(self):
+        data = dedent("""\
+            1   The     the    DET    DT   Definite=Def|PronType=Art   4   det     _   _
+            2   dog     dog    NOUN   NN   Number=Sing                 5   nmod    _   SpaceAfter=No
+            3  .       .      PUNCT  .    _                           5   punct   _   _
+
+
+
+            1   The     the    DET    DT   Definite=Def|PronType=Art   4   det     _   _
+            2   dog     dog    NOUN   NN   Number=Sing                 5   nmod    _   SpaceAfter=No
+            3  .       .      PUNCT  .    _                           5   punct   _   _
+
+
+
+        """)
+        with self.subTest("parse"):
+            self.assertEqual(
+                text(parse(data)),
+                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+            )
+
+        with self.subTest("parse_incr"):
+            self.assertEqual(
+                text([item for item in parse_incr(io.StringIO(data))]),
+                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+            )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,17 +22,17 @@ class TestParse(unittest.TestCase):
             3  .       .      PUNCT  .    _                           5   punct   _   _
 
         """)
-        with self.subTest("parse"):
-            self.assertEqual(
-                text(parse(data)),
-                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
-            )
+        # with self.subTest("parse"):
+        self.assertEqual(
+            text(parse(data)),
+            "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+        )
 
-        with self.subTest("parse_incr"):
-            self.assertEqual(
-                text([item for item in parse_incr(io.StringIO(data))]),
-                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
-            )
+        # with self.subTest("parse_incr"):
+        self.assertEqual(
+            text([item for item in parse_incr(io.StringIO(data))]),
+            "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+        )
 
     def test_multi_empty_line_end(self):
         data = dedent("""\
@@ -49,14 +49,14 @@ class TestParse(unittest.TestCase):
 
 
         """)
-        with self.subTest("parse"):
-            self.assertEqual(
-                text(parse(data)),
-                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
-            )
+        # with self.subTest("parse"):
+        self.assertEqual(
+            text(parse(data)),
+            "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+        )
 
-        with self.subTest("parse_incr"):
-            self.assertEqual(
-                text([item for item in parse_incr(io.StringIO(data))]),
-                "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
-            )
+        # with self.subTest("parse_incr"):
+        self.assertEqual(
+            text([item for item in parse_incr(io.StringIO(data))]),
+            "[TokenList<The, dog, .>, TokenList<The, dog, .>]"
+        )


### PR DESCRIPTION
There are files where between sentences there is more than one empty line (\n). The "parser" method works out correctly, but "parser_incr" raise an exception.