### PR TITLE
Resolve #34: DEPREL now supports capital letters and numbers at the end

### DIFF
--- a/conllu/parser.py
+++ b/conllu/parser.py
@@ -141,7 +141,7 @@ def parse_id_value(value):
 
 
 ANY_ID = re.compile(ID_SINGLE.pattern + "|" + ID_RANGE.pattern + "|" + ID_DOT_ID.pattern)
-DEPS_RE = re.compile("(" + ANY_ID.pattern + r"):[a-z][a-z_-]*(\:[a-z][a-z_-]*)?")
+DEPS_RE = re.compile("(" + ANY_ID.pattern + r"):[a-zA-Z][a-zA-Z0-9_-]*(\:[a-zA-Z][a-zA-Z0-9_-]*)?")
 MULTI_DEPS_PATTERN = re.compile(r"{}(\|{})*".format(DEPS_RE.pattern, DEPS_RE.pattern))
 
 def parse_paired_list_value(value):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -345,6 +345,14 @@ class TestParsePairedListValue(unittest.TestCase):
             parse_paired_list_value("5:conj:and|8.1:nsubj:pass|9:nsubj:xsubj"),
             [("conj:and", 5), ("nsubj:pass", (8, ".", 1)), ("nsubj:xsubj", 9)]
         )
+        self.assertEqual(
+            parse_paired_list_value("1:compound|6:ARG|9:ARG1|10:ARG2"),
+            [('compound', 1), ('ARG', 6), ('ARG1', 9), ('ARG2', 10)]
+        )
+        self.assertNotEqual(
+            parse_paired_list_value("1:compound|6:ARG|9:ARG1|10:2ARG"),
+            [('compound', 1), ('ARG', 6), ('ARG1', 9), ('2ARG', 10)]
+        )
 
     def test_parse_empty(self):
         testcases = [


### PR DESCRIPTION
Related to https://github.com/EmilStenstrom/conllu/issues/34:

I changed the regex so that small and capitalized letters a treated equally and that it is possible to add numbers as well (but not as a first character).

Also added two tests to confirm this works as expected.