### PR TITLE
fixed eud length and unicode alphabetic chars

### DIFF
--- a/conllu/compat.py
+++ b/conllu/compat.py
@@ -83,11 +83,11 @@ try:
 except ImportError:
     from re import match
 
-    def fullmatch(regex, *args):
+    def fullmatch(regex, *args, **kwargs):
         if not regex.pattern.endswith("$"):
-            return match(regex.pattern + "$", *args)
+            return match(regex.pattern + "$", *args, flags=regex.flags, **kwargs)
 
-        return match(regex.pattern, *args)
+        return match(regex.pattern, *args, **kwargs)
 
 try:
     unicode('')

--- a/conllu/parser.py
+++ b/conllu/parser.py
@@ -194,8 +194,8 @@ def parse_id_value(value):
 
 
 ANY_ID = re.compile(ID_SINGLE.pattern + "|" + ID_RANGE.pattern + "|" + ID_DOT_ID.pattern)
-DEPS_RE = re.compile("(" + ANY_ID.pattern + r"):[a-zA-Z][a-zA-Z0-9_-]*(\:[a-zA-Z][a-zA-Z0-9_-]*)?")
-MULTI_DEPS_PATTERN = re.compile(r"{}(\|{})*".format(DEPS_RE.pattern, DEPS_RE.pattern))
+DEPS_RE = re.compile("(" + ANY_ID.pattern + r")(:[^\W\d_]+[\w-]*)+", re.UNICODE)
+MULTI_DEPS_PATTERN = re.compile(r"{}(\|{})*".format(DEPS_RE.pattern, DEPS_RE.pattern), re.UNICODE)
 
 def parse_paired_list_value(value):
     if fullmatch(MULTI_DEPS_PATTERN, value):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -466,6 +466,14 @@ class TestParsePairedListValue(unittest.TestCase):
             parse_paired_list_value("0:root"),
             [('root', 0)]
         )
+        self.assertEqual(
+            parse_paired_list_value("1:obl:arg:gen"),
+            [('obl:arg:gen', 1)]
+        )
+        self.assertEqual(
+            parse_paired_list_value("25:obl:arg:į"),
+            [('obl:arg:į', 25)]
+        )
 
     def test_parse_empty(self):
         testcases = [


### PR DESCRIPTION
This PR modifies the MULTI_DEPS_PATTERN in 3 ways:
* It extends it to deal with arbitrary length of colon + character sequences, it was limited to 2 previously but it can be at least 3 (e.g. 1:obl:arg:gen in the Lithuanian training set).
* It deals with all unicode alphabetic characters.
* I simplified it, I'm not sure why the colon + characters pattern was repeated.

Tested on English, Tamil and Lithuanian.