### PR TITLE
Rename upostag -> upos and xpostag -> xpos, as specified on latest CoNLL-U spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,16 +198,16 @@ To quickly visualize the tree structure you can call `print_tree` on a TokenTree
 
 ```python
 >>> root.print_tree()
-(deprel:root) form:jumps lemma:jump upostag:VERB [5]
-    (deprel:nsubj) form:fox lemma:fox upostag:NOUN [4]
-        (deprel:det) form:The lemma:the upostag:DET [1]
-        (deprel:amod) form:quick lemma:quick upostag:ADJ [2]
-        (deprel:amod) form:brown lemma:brown upostag:ADJ [3]
-    (deprel:nmod) form:dog lemma:dog upostag:NOUN [9]
-        (deprel:case) form:over lemma:over upostag:ADP [6]
-        (deprel:det) form:the lemma:the upostag:DET [7]
-        (deprel:amod) form:lazy lemma:lazy upostag:ADJ [8]
-    (deprel:punct) form:. lemma:. upostag:PUNCT [10]
+(deprel:root) form:jumps lemma:jump upos:VERB [5]
+    (deprel:nsubj) form:fox lemma:fox upos:NOUN [4]
+        (deprel:det) form:The lemma:the upos:DET [1]
+        (deprel:amod) form:quick lemma:quick upos:ADJ [2]
+        (deprel:amod) form:brown lemma:brown upos:ADJ [3]
+    (deprel:nmod) form:dog lemma:dog upos:NOUN [9]
+        (deprel:case) form:over lemma:over upos:ADP [6]
+        (deprel:det) form:the lemma:the upos:DET [7]
+        (deprel:amod) form:lazy lemma:lazy upos:ADJ [8]
+    (deprel:punct) form:. lemma:. upos:PUNCT [10]
 ```
 
 To access the token corresponding to the current node in the tree, use `token`:

--- a/conllu/models.py
+++ b/conllu/models.py
@@ -3,7 +3,7 @@ from __future__ import print_function, unicode_literals
 from conllu.compat import text
 from conllu.parser import ParseException, head_to_token, serialize
 
-DEFAULT_EXCLUDE_FIELDS = ('id', 'deprel', 'xpostag', 'feats', 'head', 'deps', 'misc')
+DEFAULT_EXCLUDE_FIELDS = ('id', 'deprel', 'xpos', 'feats', 'head', 'deps', 'misc')
 
 
 class TokenList(list):

--- a/conllu/parser.py
+++ b/conllu/parser.py
@@ -5,10 +5,10 @@ from collections import OrderedDict, defaultdict
 
 from conllu.compat import fullmatch, text
 
-DEFAULT_FIELDS = ('id', 'form', 'lemma', 'upostag', 'xpostag', 'feats', 'head', 'deprel', 'deps', 'misc')
+DEFAULT_FIELDS = ('id', 'form', 'lemma', 'upos', 'xpos', 'feats', 'head', 'deprel', 'deps', 'misc')
 DEFAULT_FIELD_PARSERS = {
     "id": lambda line, i: parse_id_value(line[i]),
-    "xpostag": lambda line, i: parse_nullable_value(line[i]),
+    "xpos": lambda line, i: parse_nullable_value(line[i]),
     "feats": lambda line, i: parse_dict_value(line[i]),
     "head": lambda line, i: parse_int_value(line[i]),
     "deps": lambda line, i: parse_paired_list_value(line[i]),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,8 +46,8 @@ class TestParse(unittest.TestCase):
                 ('id', 1),
                 ('form', 'The'),
                 ('lemma', 'the'),
-                ('upostag', 'DET'),
-                ('xpostag', 'DT'),
+                ('upos', 'DET'),
+                ('xpos', 'DT'),
                 ('feats', OrderedDict([('Definite', 'Def'), ('PronType', 'Art')])),
                 ('head', 4),
                 ('deprel', 'det'),
@@ -61,8 +61,8 @@ class TestParse(unittest.TestCase):
                 ('id', 9),
                 ('form', 'dog'),
                 ('lemma', 'dog'),
-                ('upostag', 'NOUN'),
-                ('xpostag', 'NN'),
+                ('upos', 'NOUN'),
+                ('xpos', 'NN'),
                 ('feats', OrderedDict([('Number', 'Sing')])),
                 ('head', 5),
                 ('deprel', 'nmod'),
@@ -93,8 +93,8 @@ class TestParse(unittest.TestCase):
                 ('id', 5),
                 ('form', 'jumps'),
                 ('lemma', 'jump'),
-                ('upostag', 'VERB'),
-                ('xpostag', 'VBZ'),
+                ('upos', 'VERB'),
+                ('xpos', 'VBZ'),
                 ('feats', OrderedDict([
                     ("Mood", "Ind"),
                     ("Number", "Sing"),
@@ -128,16 +128,16 @@ class TestParse(unittest.TestCase):
         self.assertEqual(
             capture_print(root.print_tree),
             dedent("""\
-                (deprel:root) form:jumps lemma:jump upostag:VERB [5]
-                    (deprel:nsubj) form:fox lemma:fox upostag:NOUN [4]
-                        (deprel:det) form:The lemma:the upostag:DET [1]
-                        (deprel:amod) form:quick lemma:quick upostag:ADJ [2]
-                        (deprel:amod) form:brown lemma:brown upostag:ADJ [3]
-                    (deprel:nmod) form:dog lemma:dog upostag:NOUN [9]
-                        (deprel:case) form:over lemma:over upostag:ADP [6]
-                        (deprel:det) form:the lemma:the upostag:DET [7]
-                        (deprel:amod) form:lazy lemma:lazy upostag:ADJ [8]
-                    (deprel:punct) form:. lemma:. upostag:PUNCT [10]
+                (deprel:root) form:jumps lemma:jump upos:VERB [5]
+                    (deprel:nsubj) form:fox lemma:fox upos:NOUN [4]
+                        (deprel:det) form:The lemma:the upos:DET [1]
+                        (deprel:amod) form:quick lemma:quick upos:ADJ [2]
+                        (deprel:amod) form:brown lemma:brown upos:ADJ [3]
+                    (deprel:nmod) form:dog lemma:dog upos:NOUN [9]
+                        (deprel:case) form:over lemma:over upos:ADP [6]
+                        (deprel:det) form:the lemma:the upos:DET [7]
+                        (deprel:amod) form:lazy lemma:lazy upos:ADJ [8]
+                    (deprel:punct) form:. lemma:. upos:PUNCT [10]
             """)
         )
 
@@ -282,7 +282,7 @@ class TestParseCoNLL2009(unittest.TestCase):
         sentences = parse(
             data,
             fields=(
-                'id', 'form', 'lemma', 'upostag', 'xpostag', 'feats', 'head', 'deprel', 'deps', 'misc'
+                'id', 'form', 'lemma', 'upos', 'xpos', 'feats', 'head', 'deprel', 'deps', 'misc'
             ),
             field_parsers={
                 "feats": lambda line, i: [feat for feat in line[i].split("|")]
@@ -294,8 +294,8 @@ class TestParseCoNLL2009(unittest.TestCase):
                 ('id', 5),
                 ('form', 'regnante'),
                 ('lemma', 'regno'),
-                ('upostag', 't'),
-                ('xpostag', 't'),
+                ('upos', 't'),
+                ('xpos', 't'),
                 ('feats', ['t', '-', 's', 'p', 'p', 'a', 'm', 'b', '-']),
                 ('head', 0),
                 ('deprel', 'ADV'),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -259,8 +259,8 @@ class TestParseLine(unittest.TestCase):
                 ('id', 1),
                 ('form', 'The'),
                 ('lemma', 'the'),
-                ('upostag', 'DET'),
-                ('xpostag', 'DT'),
+                ('upos', 'DET'),
+                ('xpos', 'DT'),
                 ('feats', OrderedDict([('Definite', 'Def'), ('PronType', 'Art')])),
                 ('head', 4),
                 ('deprel', 'det'),
@@ -277,8 +277,8 @@ class TestParseLine(unittest.TestCase):
                 ('id', None),
                 ('form', '_'),
                 ('lemma', '_'),
-                ('upostag', '_'),
-                ('xpostag', None),
+                ('upos', '_'),
+                ('xpos', None),
                 ('feats', None),
                 ('head', None),
                 ('deprel', '_'),
@@ -300,8 +300,8 @@ class TestParseLine(unittest.TestCase):
             ('id', 1),
             ('form', 'The'),
             ('lemma', 'the'),
-            ('upostag', 'DET'),
-            ('xpostag', 'DT'),
+            ('upos', 'DET'),
+            ('xpos', 'DT'),
         ]))
 
     def test_parse_line_without_spacing(self):


### PR DESCRIPTION
UPOSTAG and XPOSTAG have been renamed to UPOS and XPOS about 2 years ago:
https://universaldependencies.org/format