### PR TITLE
Ignore nodes without head when creating the tree.

### DIFF
--- a/conllu/models.py
+++ b/conllu/models.py
@@ -93,7 +93,8 @@ class TokenList(T.List[Token]):
 
             # Filter out tokens with negative head, they are sometimes used to
             # specify tokens which should not be included in tree
-            if token["head"] < 0:
+            # Also filter out those that have no head, just exclude them from the tree.
+            if (token.get("head") is None) or token["head"] < 0:
                 continue
 
             head_indexed[token["head"]].append(token)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -645,6 +645,20 @@ class TestHeadToToken(unittest.TestCase):
             }
         )
 
+    def test_none_head(self):
+        self.assertEqual(
+            head_to_token([
+                {"data": "a", "head": 0},
+                {"data": "dog", "head": 1},
+                {"data": "wags", "head": None},
+                {"data": "tail", "head": None},
+            ]),
+            {
+                0: [{"data": "a", "head": 0}],
+                1: [{"data": "dog", "head": 1}],
+            }
+        )
+
     def test_range_ids_ignored(self):
         self.assertEqual(
             dict(head_to_token([


### PR DESCRIPTION
I had some conll files that included an `_` in place of a head reference. This patch enables parsing such data regardless.
Such tokens are not included in the resulting tree, just as if they had a negative head reference.