### PR TITLE
Change handling dicts for proper rendering of fields

### DIFF
--- a/conllu/serializer.py
+++ b/conllu/serializer.py
@@ -11,10 +11,16 @@ def serialize_field(field: T.Any) -> str:
         return '_'
 
     if isinstance(field, dict):
+        if field == {}:
+            return '_'
+
         fields = []
         for key, value in field.items():
             if value is None:
                 value = "_"
+            if value == "":
+                fields.append(key)
+                continue
 
             fields.append('='.join((key, value)))
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -751,6 +751,15 @@ class TestSerializeField(unittest.TestCase):
         data = [("nsubj", 2), ("nmod", 1)]
         self.assertEqual(serialize_field(data), "2:nsubj|1:nmod")
 
+    def test_blank_dict(self):
+        data = {}
+        self.assertEqual(serialize_field(data), "_")
+
+    def test_dict_with_blank_value(self):
+        data = {"key1": "value1", "key2": ""}
+        self.assertEqual(serialize_field(data), "key1=value1|key2")
+
+
 class TestSerialize(unittest.TestCase):
     def test_identity_unicode(self):
         data = "5\tlängtar\n\n"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -721,7 +721,7 @@ class TestHeadToToken(unittest.TestCase):
 class TestSerializeField(unittest.TestCase):
     def test_ordered_dict(self):
         data = Token()
-        self.assertEqual(serialize_field(data), "")
+        self.assertEqual(serialize_field(data), "_")
 
         data = Token([('SpaceAfter', 'No')])
         self.assertEqual(serialize_field(data), "SpaceAfter=No")


### PR DESCRIPTION
- Handle blank dict being not rendered
- Handle blank value for an existing key being rendered improperly
- Add tests to check for two cases above

Reference Issue:  Issue #66 