### PR TITLE
Type-flexible dict serializer

### DIFF
--- a/conllu/serializer.py
+++ b/conllu/serializer.py
@@ -21,8 +21,9 @@ def serialize_field(field: T.Any) -> str:
             if value == "":
                 fields.append(key)
                 continue
-
-            fields.append(f'{key}={value}')
+            if any(isinstance(value, serializable_type) for serializable_type in (int, float, str, bool)):
+                fields.append(f'{key}={value}')
+                continue
 
         return '|'.join(fields)
 

--- a/conllu/serializer.py
+++ b/conllu/serializer.py
@@ -22,7 +22,7 @@ def serialize_field(field: T.Any) -> str:
                 fields.append(key)
                 continue
 
-            fields.append('='.join((key, value)))
+            fields.append(f'{key}={value}')
 
         return '|'.join(fields)
 

--- a/conllu/serializer.py
+++ b/conllu/serializer.py
@@ -6,6 +6,9 @@ if T.TYPE_CHECKING:
     from conllu.models import TokenList
 
 
+SERIALIZABLE_TERMINAL_VALUE_TYPES = (int, float, bool, str)
+
+
 def serialize_field(field: T.Any) -> str:
     if field is None:
         return '_'
@@ -21,9 +24,12 @@ def serialize_field(field: T.Any) -> str:
             if value == "":
                 fields.append(key)
                 continue
-            if any(isinstance(value, serializable_type) for serializable_type in (int, float, str, bool)):
+            if isinstance(value, SERIALIZABLE_TERMINAL_VALUE_TYPES):
                 fields.append(f'{key}={value}')
                 continue
+            else:
+                value_type = type(value)
+                raise TypeError(f"Received non-serializable field value of type {value_type}:\n{value}")
 
         return '|'.join(fields)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -760,6 +760,18 @@ class TestSerializeField(unittest.TestCase):
         data = {"key1": "value1", "key2": ""}
         self.assertEqual(serialize_field(data), "key1=value1|key2")
 
+    def test_dict_with_int_value(self):
+        data = {"key1": -1, "key2": 2}
+        self.assertEqual(serialize_field(data), "key1=-1|key2=2")
+
+    def test_dict_with_float_value(self):
+        data = {"key1": 0.33, "key2": 3.142}
+        self.assertEqual(serialize_field(data), "key1=0.33|key2=3.142")
+
+    def test_dict_with_bool_value(self):
+        data = {"key1": True, "key2": False}
+        self.assertEqual(serialize_field(data), "key1=True|key2=False")
+
 
 class TestSerialize(unittest.TestCase):
     def test_identity_unicode(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -768,9 +768,19 @@ class TestSerializeField(unittest.TestCase):
         data = {"key1": 0.33, "key2": 3.142}
         self.assertEqual(serialize_field(data), "key1=0.33|key2=3.142")
 
+    def test_dict_with_str_value(self):
+        data = {"key1": "foo", "key2": "bar"}
+        self.assertEqual(serialize_field(data), "key1=foo|key2=bar")
+
     def test_dict_with_bool_value(self):
         data = {"key1": True, "key2": False}
         self.assertEqual(serialize_field(data), "key1=True|key2=False")
+
+    def test_dict_with_nonserializable_type0(self):
+        _object = object()
+        data = {"key1": _object}
+        with self.assertRaises(TypeError):
+            serialize_field(data)
 
 
 class TestSerialize(unittest.TestCase):


### PR DESCRIPTION
PR makes a modification to serializer.py, allowing dict serialization (e.g. in _misc_ column of conllu format) to take int, float, and bool types as values.