### PR TITLE
Fixes metadata propagation

### DIFF
--- a/conllu/models.py
+++ b/conllu/models.py
@@ -95,11 +95,11 @@ class TokenList(T.List[Token]):
         return TokenList(tokens_copy, self.metadata, self.default_fields)
 
     def extend(self, iterable: T.Union['TokenList', T.Iterable[Token]]) -> None:
+        if not hasattr(self, "metadata"):
+            self.metadata = Metadata()
         if not isinstance(iterable, TokenList):
             iterable = TokenList(iterable)
-
         super(TokenList, self).extend(iterable)
-
         self.metadata.update(iterable.metadata)
 
     def _dict_to_token_and_set_defaults(self, token: T.Union[dict, Token]) -> Token:
@@ -353,6 +353,8 @@ class SentenceList(T.List[TokenList]):
         return SentenceList(sentences_copy, self.metadata)
 
     def extend(self, iterable: T.Union['SentenceList', T.Iterable[TokenList]]) -> None:
+        if not hasattr(self, "metadata"):
+            self.metadata = Metadata()
         if not isinstance(iterable, SentenceList):
             iterable = SentenceList(iterable)
 

--- a/conllu/models.py
+++ b/conllu/models.py
@@ -187,7 +187,7 @@ class TokenList(T.List[Token]):
         return root
 
     def filter(self, **kwargs: T.Any) -> 'TokenList':
-        tokens: T.Iterable[Token] = self.copy()
+        tokens = self.copy()
 
         for query, value in kwargs.items():
             filtered_tokens = []
@@ -198,9 +198,9 @@ class TokenList(T.List[Token]):
                     if traverse_dict(token, query) == value:
                         filtered_tokens.append(token)
 
-            tokens = filtered_tokens
+            tokens[:] = filtered_tokens
 
-        return TokenList(tokens)
+        return tokens
 
 
 _T = T.TypeVar("_T")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,40 +49,41 @@ class TestToken(unittest.TestCase):
         self.assertEqual(str(Token({"id": 1})), "id=1")
         self.assertEqual(str(Token({"x": 1})), "")
 
-
 class TestTokenList(unittest.TestCase):
     def test_constructor(self):
         with self.assertRaises(ParseException):
             TokenList({"id": 1})
 
     def test_eq(self):
-        self.assertEqual(TokenList([{"id": 1}]), TokenList([{"id": 1}]))
+        self.assertEqual(
+            TokenList([{"id": 1}]),
+            TokenList([{"id": 1}])
+        )
         self.assertNotEqual(
             TokenList([{"id": 1}], metadata={"meta": "data"}),
-            TokenList([{"id": 1}]),
+            TokenList([{"id": 1}])
         )
         self.assertEqual(
             TokenList([{"id": 1}], metadata={"meta": "data"}),
-            TokenList([{"id": 1}], metadata={"meta": "data"}),
+            TokenList([{"id": 1}], metadata={"meta": "data"})
         )
-        self.assertEqual(TokenList([{"id": 1}]), [{"id": 1}])
+        self.assertEqual(
+            TokenList([{"id": 1}]),
+            [{"id": 1}]
+        )
 
     def test_len(self):
         tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
         self.assertEqual(3, len(tokenlist))
 
     def test_clear(self):
-        tokenlist = TokenList(
-            [{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"}
-        )
+        tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
         tokenlist.clear()
         self.assertEqual(len(tokenlist), 0)
         self.assertEqual(tokenlist.metadata, Metadata())
 
     def test_copy(self):
-        tokenlist1 = TokenList(
-            [{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"}
-        )
+        tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
         tokenlist2 = tokenlist1.copy()
         self.assertIsNot(tokenlist1, tokenlist2)
         self.assertEqual(tokenlist1, tokenlist2)
@@ -91,31 +92,21 @@ class TestTokenList(unittest.TestCase):
         tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
         tokenlist2 = [{"id": 4}, {"id": 5}, {"id": 6}]
         tokenlist1.extend(tokenlist2)
-        tokenlist3 = TokenList(
-            [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}]
-        )
+        tokenlist3 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}])
         self.assertEqual(tokenlist1, tokenlist3)
 
     def test_extend_tokenlist_and_merge_metadata(self):
-        tokenlist4 = TokenList(
-            [{"id": 1}, {"id": 2}, {"id": 3}], {"meta1": "data1"}
-        )
-        tokenlist5 = TokenList(
-            [{"id": 4}, {"id": 5}, {"id": 6}], {"meta2": "data2"}
-        )
+        tokenlist4 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta1": "data1"})
+        tokenlist5 = TokenList([{"id": 4}, {"id": 5}, {"id": 6}], {"meta2": "data2"})
         tokenlist4.extend(tokenlist5)
-        tokenlist6 = TokenList(
-            [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}],
-            {"meta1": "data1", "meta2": "data2"},
-        )
+        tokenlist6 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}],
+                               {"meta1": "data1", "meta2": "data2"})
         self.assertEqual(tokenlist4, tokenlist6)
 
     def test_extend_with_dict_list(self):
         tokenlist = TokenList([{"id": 1}])
         tokenlist.extend([{"id": 2}, {"id": 3}])
-        self.assertEqual(
-            tokenlist, TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
-        )
+        self.assertEqual(tokenlist, TokenList([{"id": 1}, {"id": 2}, {"id": 3}]))
 
     def test_empty(self):
         tokenlist = TokenList()
@@ -184,7 +175,6 @@ class TestTokenList(unittest.TestCase):
         tokenlist[1]["id"] = 3
         self.assertEqual(tokenlist[1]["id"], 3)
 
-
 class TestParsingTrickyTrees(unittest.TestCase):
     def assertTreeEqual(self, tree, other):
         self.assertEqual(tree.token, other.token)
@@ -193,109 +183,87 @@ class TestParsingTrickyTrees(unittest.TestCase):
             self.assertTreeEqual(child, other.children[i])
 
     def test_simple_tree(self):
-        tokenlist = TokenList(
-            [
-                Token([("id", 2), ("form", "dog"), ("head", 0)]),
-                Token([("id", 1), ("form", "a"), ("head", 2)]),
-            ]
-        )
+        tokenlist = TokenList([
+            Token([("id", 2), ("form", "dog"), ("head", 0)]),
+            Token([("id", 1), ("form", "a"), ("head", 2)]),
+        ])
         tree = TokenTree(
             token=Token([("id", 2), ("form", "dog"), ("head", 0)]),
-            children=[
-                TokenTree(
-                    token=Token([("id", 1), ("form", "a"), ("head", 2)]),
-                    children=[],
-                )
-            ],
+            children=[TokenTree(
+                token=Token([("id", 1), ("form", "a"), ("head", 2)]),
+                children=[]
+            )]
         )
         self.assertTreeEqual(tokenlist.to_tree(), tree)
 
     def test_removes_negative_nodes(self):
-        tokenlist = TokenList(
-            [
-                Token([("id", 2), ("form", "dog"), ("head", 0)]),
-                Token([("id", 1), ("form", "a"), ("head", 2)]),
-                Token([("id", 3), ("form", "😍"), ("head", -1)]),
-            ]
-        )
+        tokenlist = TokenList([
+            Token([("id", 2), ("form", "dog"), ("head", 0)]),
+            Token([("id", 1), ("form", "a"), ("head", 2)]),
+            Token([("id", 3), ("form", "😍"), ("head", -1)]),
+        ])
         tree = TokenTree(
             token=Token([("id", 2), ("form", "dog"), ("head", 0)]),
-            children=[
-                TokenTree(
-                    token=Token([("id", 1), ("form", "a"), ("head", 2)]),
-                    children=[],
-                )
-            ],
+            children=[TokenTree(
+                token=Token([("id", 1), ("form", "a"), ("head", 2)]),
+                children=[]
+            )]
         )
         self.assertTreeEqual(tokenlist.to_tree(), tree)
 
     def test_multiple_root_nodes(self):
-        tokenlist = TokenList(
-            [
-                Token([("id", 1), ("form", "To"), ("head", 0)]),
-                Token([("id", 2), ("form", "appear"), ("head", 1)]),
-                Token([("id", 4), ("form", "EMNLP"), ("head", 0)]),
-                Token([("id", 5), ("form", "2014"), ("head", 4)]),
-                Token([("id", 6), ("form", "Yay!"), ("head", 0)]),
-            ]
-        )
+        tokenlist = TokenList([
+            Token([('id', 1), ('form', 'To'), ('head', 0)]),
+            Token([('id', 2), ('form', 'appear'), ('head', 1)]),
+            Token([('id', 4), ('form', 'EMNLP'), ('head', 0)]),
+            Token([('id', 5), ('form', '2014'), ('head', 4)]),
+            Token([('id', 6), ('form', 'Yay!'), ('head', 0)]),
+        ])
         tree = TokenTree(
             token=Token([("id", 0), ("form", "_"), ("deprel", "root")]),
             children=[
                 TokenTree(
                     token=Token([("id", 1), ("form", "To"), ("head", 0)]),
-                    children=[
-                        TokenTree(
-                            token=Token(
-                                [("id", 2), ("form", "appear"), ("head", 1)]
-                            ),
-                            children=[],
-                        )
-                    ],
+                    children=[TokenTree(
+                        token=Token([("id", 2), ("form", "appear"), ("head", 1)]),
+                        children=[]
+                    )]
                 ),
                 TokenTree(
                     token=Token([("id", 4), ("form", "EMNLP"), ("head", 0)]),
-                    children=[
-                        TokenTree(
-                            token=Token(
-                                [("id", 5), ("form", "2014"), ("head", 4)]
-                            ),
-                            children=[],
-                        )
-                    ],
+                    children=[TokenTree(
+                        token=Token([("id", 5), ("form", "2014"), ("head", 4)]),
+                        children=[]
+                    )]
                 ),
                 TokenTree(
                     token=Token([("id", 6), ("form", "Yay!"), ("head", 0)]),
-                    children=[],
+                    children=[]
                 ),
-            ],
+            ]
         )
         self.assertTreeEqual(tokenlist.to_tree(), tree)
 
     def test_no_root_nodes(self):
-        tokenlist = TokenList(
-            [
-                Token([("id", 1), ("form", "To"), ("head", 1)]),
-                Token([("id", 2), ("form", "appear"), ("head", 2)]),
-            ]
-        )
+        tokenlist = TokenList([
+            Token([('id', 1), ('form', 'To'), ('head', 1)]),
+            Token([('id', 2), ('form', 'appear'), ('head', 2)]),
+        ])
         with self.assertRaises(ParseException):
             tokenlist.to_tree()
 
 
 class TestSerialize(unittest.TestCase):
+
     def test_serialize_on_tokenlist(self):
         tokenlist = TokenList([{"id": 1}])
         self.assertEqual(tokenlist.serialize(), serialize(tokenlist))
 
     def test_pickling_tokenlist(self):
-        tokenlist = TokenList(
-            [
-                {"id": 1, "form": "a", "field": "x"},
-                {"id": 2, "form": "dog", "field": "x"},
-            ],
-            metadata={"text": "a dog"},
-        )
+        tokenlist = TokenList([
+            {"id": 1, "form": "a", "field": "x"},
+            {"id": 2, "form": "dog", "field": "x"},
+        ], metadata={"text": "a dog"})
         sink = tempfile.NamedTemporaryFile("wb", suffix=".pkl", delete=False)
         pickle.dump(tokenlist, sink)
         sink.close()
@@ -303,198 +271,160 @@ class TestSerialize(unittest.TestCase):
             tokenlist_copy = pickle.load(source)
         self.assertEqual(tokenlist, tokenlist_copy)
 
-
 class TestFilter(unittest.TestCase):
     def test_basic_filtering(self):
-        tokenlist = TokenList(
-            [
-                {"id": 1, "form": "a", "field": "x"},
-                {"id": 2, "form": "dog", "field": "x"},
-            ]
+        tokenlist = TokenList([
+            {"id": 1, "form": "a", "field": "x"},
+            {"id": 2, "form": "dog", "field": "x"},
+        ])
+        self.assertEqual(
+            tokenlist.filter(id=0),
+            TokenList([])
         )
-        self.assertEqual(tokenlist.filter(id=0), TokenList([]))
         self.assertEqual(
             tokenlist.filter(id=1),
-            TokenList([{"id": 1, "form": "a", "field": "x"}]),
-        )
-        self.assertEqual(tokenlist.filter(), tokenlist)
-        self.assertEqual(tokenlist.filter(field="x"), tokenlist)
-
-    def test_metadata_propagates(self):
-        tokenlist = TokenList(
-            [
-                {"id": 1, "form": "a", "field": "x"},
-                {"id": 2, "form": "dog", "field": "x"},
-            ],
-            metadata={"text": "a dog"},
+            TokenList([{"id": 1, "form": "a", "field": "x"}])
         )
         self.assertEqual(
-            tokenlist.filter(), tokenlist
+            tokenlist.filter(),
+            tokenlist
+        )
+        self.assertEqual(
+            tokenlist.filter(field="x"),
+            tokenlist
+        )
+
+    def test_metadata_propagates(self):
+        tokenlist = TokenList([
+            {"id": 1, "form": "a", "field": "x"},
+            {"id": 2, "form": "dog", "field": "x"},
+        ], metadata={"text": "a dog"})
+        self.assertEqual(
+            tokenlist.filter().metadata,
+            tokenlist.metadata,
         )
 
     def test_and_filtering(self):
-        tokenlist = TokenList(
-            [
-                {"id": 1, "form": "a", "field": "x"},
-                {"id": 2, "form": "dog", "field": "x"},
-                {"id": 3, "form": "dog", "field": "y"},
-            ]
-        )
+        tokenlist = TokenList([
+            {"id": 1, "form": "a", "field": "x"},
+            {"id": 2, "form": "dog", "field": "x"},
+            {"id": 3, "form": "dog", "field": "y"},
+        ])
         self.assertEqual(
             tokenlist.filter(field="x", id=2),
-            TokenList(
-                [
-                    {"id": 2, "form": "dog", "field": "x"},
-                ]
-            ),
-        )
-        self.assertEqual(tokenlist.filter(field="x", id=3), TokenList([]))
-
-    def test_deep_filtering(self):
-        tokenlist = TokenList(
-            [
-                {
-                    "form": "The",
-                    "feats": Token([("Definite", "Def"), ("PronType", "Art")]),
-                },
-                {"form": "quick", "feats": Token([("Degree", "Pos")])},
-                {"form": "brown", "feats": Token([("Degree", "Pos")])},
-                {"form": "fox", "feats": Token([("Number", "Sing")])},
-            ]
+            TokenList([
+                {"id": 2, "form": "dog", "field": "x"},
+            ])
         )
         self.assertEqual(
+            tokenlist.filter(field="x", id=3),
+            TokenList([])
+        )
+
+    def test_deep_filtering(self):
+        tokenlist = TokenList([
+            {"form": "The", "feats": Token([('Definite', 'Def'), ('PronType', 'Art')])},
+            {"form": "quick", "feats": Token([('Degree', 'Pos')])},
+            {"form": "brown", "feats": Token([('Degree', 'Pos')])},
+            {"form": "fox", "feats": Token([('Number', 'Sing')])},
+        ])
+        self.assertEqual(
             tokenlist.filter(feats__Degree="Pos"),
-            TokenList(
-                [
-                    {"form": "quick", "feats": Token([("Degree", "Pos")])},
-                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
-                ]
-            ),
+            TokenList([
+                {"form": "quick", "feats": Token([('Degree', 'Pos')])},
+                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
+            ])
         )
         self.assertEqual(
             tokenlist.filter(form="brown", feats__Degree="Pos"),
-            TokenList(
-                [
-                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
-                ]
-            ),
+            TokenList([
+                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
+            ])
         )
         self.assertEqual(
             tokenlist.filter(form="brown", feats__Degree="Pos", id=1),
-            TokenList([]),
+            TokenList([])
         )
         self.assertEqual(
             tokenlist.filter(unknown__property__value="undefined"),
-            TokenList([]),
+            TokenList([])
         )
         self.assertEqual(
             tokenlist.filter(unknown___property____value="undefined"),
-            TokenList([]),
+            TokenList([])
         )
 
     def test_nested_filtering(self):
-        tokenlist = TokenList(
-            [
-                {
-                    "form": "The",
-                    "feats": Token([("Definite", "Def"), ("PronType", "Art")]),
-                },
-                {"form": "quick", "feats": Token([("Degree", "Pos")])},
-                {"form": "brown", "feats": Token([("Degree", "Pos")])},
-                {"form": "fox", "feats": Token([("Number", "Sing")])},
-            ]
-        )
+        tokenlist = TokenList([
+            {"form": "The", "feats": Token([('Definite', 'Def'), ('PronType', 'Art')])},
+            {"form": "quick", "feats": Token([('Degree', 'Pos')])},
+            {"form": "brown", "feats": Token([('Degree', 'Pos')])},
+            {"form": "fox", "feats": Token([('Number', 'Sing')])},
+        ])
         self.assertEqual(
             tokenlist.filter(feats__Degree="Pos").filter(form="brown"),
-            TokenList(
-                [
-                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
-                ]
-            ),
+            TokenList([
+                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
+            ])
         )
         self.assertEqual(
             tokenlist.filter(form="brown").filter(feats__Degree="Pos"),
-            TokenList(
-                [
-                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
-                ]
-            ),
+            TokenList([
+                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
+            ])
         )
         self.assertEqual(
-            tokenlist.filter(form="brown")
-            .filter(feats__Degree="Pos")
-            .filter(),
-            TokenList(
-                [
-                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
-                ]
-            ),
+            tokenlist.filter(form="brown").filter(feats__Degree="Pos").filter(),
+            TokenList([
+                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
+            ])
         )
         self.assertEqual(
-            tokenlist.filter(form="brown")
-            .filter(feats__Degree="Pos")
-            .filter(id=0),
-            TokenList([]),
+            tokenlist.filter(form="brown").filter(feats__Degree="Pos").filter(id=0),
+            TokenList([])
         )
 
     def test_lambda_basic_filtering(self):
-        tokenlist = TokenList(
-            [
-                Token(
-                    {
-                        "id": (1, "-", 2),
-                        "form": "It's",
-                        "lemma": "_",
-                        "feats": None,
-                    }
-                ),
-                Token({"id": 1, "form": "It", "lemma": "it"}),
-                Token({"id": 2, "form": "'s", "lemma": "be"}),
-            ]
-        )
+        tokenlist = TokenList([
+            Token({'id': (1, '-', 2), 'form': "It's", 'lemma': '_', 'feats': None}),
+            Token({'id': 1, 'form': 'It', 'lemma': 'it'}),
+            Token({'id': 2, 'form': "'s", 'lemma': 'be'})
+        ])
 
         self.assertEqual(
             tokenlist.filter(id=lambda x: type(x) is int),
-            TokenList(
-                [
-                    Token({"id": 1, "form": "It", "lemma": "it"}),
-                    Token({"id": 2, "form": "'s", "lemma": "be"}),
-                ]
-            ),
+            TokenList([
+                Token({'id': 1, 'form': 'It', 'lemma': 'it'}),
+                Token({'id': 2, 'form': "'s", 'lemma': 'be'})
+            ])
         )
         self.assertEqual(
-            tokenlist.filter(lemma=lambda x: x.startswith("b")),
-            TokenList([Token({"id": 2, "form": "'s", "lemma": "be"})]),
+            tokenlist.filter(lemma=lambda x: x.startswith('b')),
+            TokenList([
+                Token({'id': 2, 'form': "'s", 'lemma': 'be'})
+            ])
         )
 
     def test_lambda_deep_filtering(self):
-        tokenlist = TokenList(
-            [
-                Token({"id": (1, "-", 2), "feats": None}),
-                Token({"id": 1, "feats": {"Case": "Nom", "Number": "Sing"}}),
-                Token({"id": 2, "feats": {"Mood": "Ind", "Number": "Sing"}}),
-            ]
+        tokenlist = TokenList([
+            Token({'id': (1, '-', 2), 'feats': None}),
+            Token({'id': 1, 'feats': {'Case': 'Nom', 'Number': 'Sing'}}),
+            Token({'id': 2, 'feats': {'Mood': 'Ind', 'Number': 'Sing'}})
+        ])
+
+        self.assertEqual(
+            tokenlist.filter(feats__Mood=lambda x: x == 'Ind'),
+            TokenList([
+                Token({'id': 2, 'feats': {'Mood': 'Ind', 'Number': 'Sing'}})
+            ])
         )
 
         self.assertEqual(
-            tokenlist.filter(feats__Mood=lambda x: x == "Ind"),
-            TokenList(
-                [Token({"id": 2, "feats": {"Mood": "Ind", "Number": "Sing"}})]
-            ),
-        )
-
-        self.assertEqual(
-            tokenlist.filter(feats__Number=lambda x: x == "Sing"),
-            TokenList(
-                [
-                    Token(
-                        {"id": 1, "feats": {"Case": "Nom", "Number": "Sing"}}
-                    ),
-                    Token(
-                        {"id": 2, "feats": {"Mood": "Ind", "Number": "Sing"}}
-                    ),
-                ]
-            ),
+            tokenlist.filter(feats__Number=lambda x: x == 'Sing'),
+            TokenList([
+                Token({'id': 1, 'feats': {'Case': 'Nom', 'Number': 'Sing'}}),
+                Token({'id': 2, 'feats': {'Mood': 'Ind', 'Number': 'Sing'}})
+            ])
         )
 
 
@@ -502,9 +432,7 @@ class TestTokenTree(unittest.TestCase):
     def test_eq(self):
         metadata = {"meta": "data"}
 
-        tokentree1 = TokenTree(
-            token={"id": 1}, children=[TokenTree(token={"id": 2}, children=[])]
-        )
+        tokentree1 = TokenTree(token={"id": 1}, children=[TokenTree(token={"id": 2}, children=[])])
         tokentree1.metadata = metadata
 
         tokentree2 = TokenTree(token={"id": 1}, children=[])
@@ -525,11 +453,7 @@ class TestTokenTree(unittest.TestCase):
         tree.set_metadata(metadata)
         self.assertEqual(tree.metadata, metadata)
 
-        tree = TokenTree(
-            token={"id": 1, "form": "hej"},
-            children=[],
-            metadata={"meta": "data"},
-        )
+        tree = TokenTree(token={"id": 1, "form": "hej"}, children=[], metadata={"meta": "data"})
         self.assertEqual(tree.metadata, metadata)
 
 
@@ -542,35 +466,33 @@ class TestSerializeTree(unittest.TestCase):
     def test_flatten(self):
         tree = TokenTree(
             token=Token([("id", 2), ("form", "dog")]),
-            children=[
-                TokenTree(token=Token([("id", 1), ("form", "a")]), children=[])
-            ],
+            children=[TokenTree(
+                token=Token([("id", 1), ("form", "a")]),
+                children=[]
+            )]
         )
         self.assertEqual(
             tree.serialize(),
-            dedent(
-                """\
+            dedent("""\
                 1\ta
                 2\tdog
 
-            """
-            ),
+            """)
         )
         tree = TokenTree(
             token=Token([("id", 1), ("form", "dog")]),
-            children=[
-                TokenTree(token=Token([("id", 2), ("form", "a")]), children=[])
-            ],
+            children=[TokenTree(
+                token=Token([("id", 2), ("form", "a")]),
+                children=[]
+            )]
         )
         self.assertEqual(
             tree.serialize(),
-            dedent(
-                """\
+            dedent("""\
                 1\tdog
                 2\ta
 
-            """
-            ),
+            """)
         )
 
 
@@ -591,38 +513,22 @@ class TestPrintTree(unittest.TestCase):
             capture_print(tree.print_tree)
 
     def test_print_simple(self):
-        tree = TokenTree(
-            token={"id": "X", "deprel": "Y", "test": "data"}, children=[]
-        )
+        tree = TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[])
         result = capture_print(tree.print_tree)
         self.assertEqual(result, "(deprel:Y) test:data [X]\n")
 
     def test_print_with_children(self):
-        tree = TokenTree(
-            token={"id": "X", "deprel": "Y", "test": "data"},
-            children=[
-                TokenTree(
-                    token={"id": "X", "deprel": "Y", "test": "data"},
-                    children=[],
-                ),
-                TokenTree(
-                    token={"id": "X", "deprel": "Y", "test": "data"},
-                    children=[],
-                ),
-            ],
-        )
+        tree = TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[
+            TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[]),
+            TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[]),
+        ])
         result = capture_print(tree.print_tree)
 
-        self.assertEqual(
-            result,
-            dedent(
-                """\
+        self.assertEqual(result, dedent("""\
             (deprel:Y) test:data [X]
                 (deprel:Y) test:data [X]
                 (deprel:Y) test:data [X]
-        """
-            ),
-        )
+        """))
 
 
 class TestSentenceList(unittest.TestCase):
@@ -646,9 +552,7 @@ class TestSentenceList(unittest.TestCase):
         self.assertEqual(tokenlists, SentenceList(tokenlists))
 
         tokenlists2 = [TokenList([{"id": 2}])]
-        self.assertNotEqual(
-            SentenceList(tokenlists), SentenceList(tokenlists2)
-        )
+        self.assertNotEqual(SentenceList(tokenlists), SentenceList(tokenlists2))
 
     def test_clear(self):
         sentences = SentenceList([TokenList([{"id": 1}])], metadata={"a": 1})
@@ -670,9 +574,8 @@ class TestSentenceList(unittest.TestCase):
         self.assertEqual(
             sentences,
             SentenceList(
-                [TokenList([{"id": 1}]), TokenList([{"id": 2}])],
-                metadata={"a": 1, "b": 2},
-            ),
+                [TokenList([{"id": 1}]), TokenList([{"id": 2}])], metadata={"a": 1, "b": 2}
+            )
         )
 
         sentences.extend(sentences3)
@@ -680,12 +583,9 @@ class TestSentenceList(unittest.TestCase):
             sentences,
             SentenceList(
                 [
-                    TokenList([{"id": 1}]),
-                    TokenList([{"id": 2}]),
-                    TokenList([{"id": 3}]),
-                ],
-                metadata={"a": 1, "b": 2},
-            ),
+                    TokenList([{"id": 1}]), TokenList([{"id": 2}]), TokenList([{"id": 3}])
+                ], metadata={"a": 1, "b": 2}
+            )
         )
 
     def test_slicing_sentencelist_works_and_retains_metadata(self):
@@ -695,17 +595,14 @@ class TestSentenceList(unittest.TestCase):
                 TokenList([{"id": 2}]),
                 TokenList([{"id": 3}]),
             ],
-            metadata={"a": 1},
+            metadata={"a": 1}
         )
-        self.assertEqual(
-            sentences[1:2],
-            SentenceList(
-                [
-                    TokenList([{"id": 2}]),
-                ],
-                metadata={"a": 1},
-            ),
-        )
+        self.assertEqual(sentences[1:2], SentenceList(
+            [
+                TokenList([{"id": 2}]),
+            ],
+            metadata={"a": 1}
+        ))
 
     def test_slicing_with_single_int(self):
         sentences = SentenceList(
@@ -714,10 +611,9 @@ class TestSentenceList(unittest.TestCase):
                 TokenList([{"id": 2}]),
                 TokenList([{"id": 3}]),
             ],
-            metadata={"a": 1},
+            metadata={"a": 1}
         )
         self.assertEqual(sentences[1], TokenList([{"id": 2}]))
-
 
 class TestSentenceGenerator(unittest.TestCase):
     def test_init_empty_sentences_should_not_raise(self):
@@ -740,7 +636,5 @@ class TestSentenceGenerator(unittest.TestCase):
             yield tokenlist1
             yield tokenlist2
 
-        self.assertEqual(
-            list(SentenceGenerator(two_sentences())), [tokenlist1, tokenlist2]
-        )
+        self.assertEqual(list(SentenceGenerator(two_sentences())), [tokenlist1, tokenlist2])
         self.assertEqual(next(SentenceGenerator(two_sentences())), tokenlist1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -549,7 +549,7 @@ class TestSentenceList(unittest.TestCase):
         sl = SentenceList([TokenList([{"id": 1}])])
         del sl.metadata
         sl.extend(sl)
-        self.assertTrue(hasattr(s1, "metadata"))
+        self.assertTrue(hasattr(sl, "metadata"))
         self.assertIsNotNone(sl.metadata)
 
     def test_equals(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -545,6 +545,13 @@ class TestSentenceList(unittest.TestCase):
         with self.assertRaises(ParseException):
             SentenceList((1, 2, 4))
 
+    def test_extend_with_no_metadata(self):
+        sl = SentenceList([TokenList([{"id": 1}])])
+        del sl.metadata
+        sl.extend(sl)
+        self.assertTrue(hasattr(s1, "metadata"))
+        self.assertIsNotNone(sl.metadata)
+
     def test_equals(self):
         tokenlists = [TokenList([{"id": 1}])]
         self.assertEqual(SentenceList(tokenlists), SentenceList(tokenlists))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,14 @@
 import unittest
 from textwrap import dedent
 
-from conllu.models import Metadata, SentenceGenerator, SentenceList, Token, TokenList, TokenTree
+from conllu.models import (
+    Metadata,
+    SentenceGenerator,
+    SentenceList,
+    Token,
+    TokenList,
+    TokenTree,
+)
 from conllu.parser import ParseException, serialize
 from tests.helpers import capture_print
 
@@ -47,41 +54,40 @@ class TestToken(unittest.TestCase):
         self.assertEqual(str(Token({"id": 1})), "id=1")
         self.assertEqual(str(Token({"x": 1})), "")
 
+
 class TestTokenList(unittest.TestCase):
     def test_constructor(self):
         with self.assertRaises(ParseException):
             TokenList({"id": 1})
 
     def test_eq(self):
-        self.assertEqual(
-            TokenList([{"id": 1}]),
-            TokenList([{"id": 1}])
-        )
+        self.assertEqual(TokenList([{"id": 1}]), TokenList([{"id": 1}]))
         self.assertNotEqual(
             TokenList([{"id": 1}], metadata={"meta": "data"}),
-            TokenList([{"id": 1}])
+            TokenList([{"id": 1}]),
         )
         self.assertEqual(
             TokenList([{"id": 1}], metadata={"meta": "data"}),
-            TokenList([{"id": 1}], metadata={"meta": "data"})
+            TokenList([{"id": 1}], metadata={"meta": "data"}),
         )
-        self.assertEqual(
-            TokenList([{"id": 1}]),
-            [{"id": 1}]
-        )
+        self.assertEqual(TokenList([{"id": 1}]), [{"id": 1}])
 
     def test_len(self):
         tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
         self.assertEqual(3, len(tokenlist))
 
     def test_clear(self):
-        tokenlist = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
+        tokenlist = TokenList(
+            [{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"}
+        )
         tokenlist.clear()
         self.assertEqual(len(tokenlist), 0)
         self.assertEqual(tokenlist.metadata, Metadata())
 
     def test_copy(self):
-        tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"})
+        tokenlist1 = TokenList(
+            [{"id": 1}, {"id": 2}, {"id": 3}], {"meta": "data"}
+        )
         tokenlist2 = tokenlist1.copy()
         self.assertIsNot(tokenlist1, tokenlist2)
         self.assertEqual(tokenlist1, tokenlist2)
@@ -90,21 +96,31 @@ class TestTokenList(unittest.TestCase):
         tokenlist1 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
         tokenlist2 = [{"id": 4}, {"id": 5}, {"id": 6}]
         tokenlist1.extend(tokenlist2)
-        tokenlist3 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}])
+        tokenlist3 = TokenList(
+            [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}]
+        )
         self.assertEqual(tokenlist1, tokenlist3)
 
     def test_extend_tokenlist_and_merge_metadata(self):
-        tokenlist4 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}], {"meta1": "data1"})
-        tokenlist5 = TokenList([{"id": 4}, {"id": 5}, {"id": 6}], {"meta2": "data2"})
+        tokenlist4 = TokenList(
+            [{"id": 1}, {"id": 2}, {"id": 3}], {"meta1": "data1"}
+        )
+        tokenlist5 = TokenList(
+            [{"id": 4}, {"id": 5}, {"id": 6}], {"meta2": "data2"}
+        )
         tokenlist4.extend(tokenlist5)
-        tokenlist6 = TokenList([{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}],
-                               {"meta1": "data1", "meta2": "data2"})
+        tokenlist6 = TokenList(
+            [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}, {"id": 6}],
+            {"meta1": "data1", "meta2": "data2"},
+        )
         self.assertEqual(tokenlist4, tokenlist6)
 
     def test_extend_with_dict_list(self):
         tokenlist = TokenList([{"id": 1}])
         tokenlist.extend([{"id": 2}, {"id": 3}])
-        self.assertEqual(tokenlist, TokenList([{"id": 1}, {"id": 2}, {"id": 3}]))
+        self.assertEqual(
+            tokenlist, TokenList([{"id": 1}, {"id": 2}, {"id": 3}])
+        )
 
     def test_empty(self):
         tokenlist = TokenList()
@@ -173,6 +189,7 @@ class TestTokenList(unittest.TestCase):
         tokenlist[1]["id"] = 3
         self.assertEqual(tokenlist[1]["id"], 3)
 
+
 class TestParsingTrickyTrees(unittest.TestCase):
     def assertTreeEqual(self, tree, other):
         self.assertEqual(tree.token, other.token)
@@ -181,72 +198,92 @@ class TestParsingTrickyTrees(unittest.TestCase):
             self.assertTreeEqual(child, other.children[i])
 
     def test_simple_tree(self):
-        tokenlist = TokenList([
-            Token([("id", 2), ("form", "dog"), ("head", 0)]),
-            Token([("id", 1), ("form", "a"), ("head", 2)]),
-        ])
+        tokenlist = TokenList(
+            [
+                Token([("id", 2), ("form", "dog"), ("head", 0)]),
+                Token([("id", 1), ("form", "a"), ("head", 2)]),
+            ]
+        )
         tree = TokenTree(
             token=Token([("id", 2), ("form", "dog"), ("head", 0)]),
-            children=[TokenTree(
-                token=Token([("id", 1), ("form", "a"), ("head", 2)]),
-                children=[]
-            )]
+            children=[
+                TokenTree(
+                    token=Token([("id", 1), ("form", "a"), ("head", 2)]),
+                    children=[],
+                )
+            ],
         )
         self.assertTreeEqual(tokenlist.to_tree(), tree)
 
     def test_removes_negative_nodes(self):
-        tokenlist = TokenList([
-            Token([("id", 2), ("form", "dog"), ("head", 0)]),
-            Token([("id", 1), ("form", "a"), ("head", 2)]),
-            Token([("id", 3), ("form", "😍"), ("head", -1)]),
-        ])
+        tokenlist = TokenList(
+            [
+                Token([("id", 2), ("form", "dog"), ("head", 0)]),
+                Token([("id", 1), ("form", "a"), ("head", 2)]),
+                Token([("id", 3), ("form", "😍"), ("head", -1)]),
+            ]
+        )
         tree = TokenTree(
             token=Token([("id", 2), ("form", "dog"), ("head", 0)]),
-            children=[TokenTree(
-                token=Token([("id", 1), ("form", "a"), ("head", 2)]),
-                children=[]
-            )]
+            children=[
+                TokenTree(
+                    token=Token([("id", 1), ("form", "a"), ("head", 2)]),
+                    children=[],
+                )
+            ],
         )
         self.assertTreeEqual(tokenlist.to_tree(), tree)
 
     def test_multiple_root_nodes(self):
-        tokenlist = TokenList([
-            Token([('id', 1), ('form', 'To'), ('head', 0)]),
-            Token([('id', 2), ('form', 'appear'), ('head', 1)]),
-            Token([('id', 4), ('form', 'EMNLP'), ('head', 0)]),
-            Token([('id', 5), ('form', '2014'), ('head', 4)]),
-            Token([('id', 6), ('form', 'Yay!'), ('head', 0)]),
-        ])
+        tokenlist = TokenList(
+            [
+                Token([("id", 1), ("form", "To"), ("head", 0)]),
+                Token([("id", 2), ("form", "appear"), ("head", 1)]),
+                Token([("id", 4), ("form", "EMNLP"), ("head", 0)]),
+                Token([("id", 5), ("form", "2014"), ("head", 4)]),
+                Token([("id", 6), ("form", "Yay!"), ("head", 0)]),
+            ]
+        )
         tree = TokenTree(
             token=Token([("id", 0), ("form", "_"), ("deprel", "root")]),
             children=[
                 TokenTree(
                     token=Token([("id", 1), ("form", "To"), ("head", 0)]),
-                    children=[TokenTree(
-                        token=Token([("id", 2), ("form", "appear"), ("head", 1)]),
-                        children=[]
-                    )]
+                    children=[
+                        TokenTree(
+                            token=Token(
+                                [("id", 2), ("form", "appear"), ("head", 1)]
+                            ),
+                            children=[],
+                        )
+                    ],
                 ),
                 TokenTree(
                     token=Token([("id", 4), ("form", "EMNLP"), ("head", 0)]),
-                    children=[TokenTree(
-                        token=Token([("id", 5), ("form", "2014"), ("head", 4)]),
-                        children=[]
-                    )]
+                    children=[
+                        TokenTree(
+                            token=Token(
+                                [("id", 5), ("form", "2014"), ("head", 4)]
+                            ),
+                            children=[],
+                        )
+                    ],
                 ),
                 TokenTree(
                     token=Token([("id", 6), ("form", "Yay!"), ("head", 0)]),
-                    children=[]
+                    children=[],
                 ),
-            ]
+            ],
         )
         self.assertTreeEqual(tokenlist.to_tree(), tree)
 
     def test_no_root_nodes(self):
-        tokenlist = TokenList([
-            Token([('id', 1), ('form', 'To'), ('head', 1)]),
-            Token([('id', 2), ('form', 'appear'), ('head', 2)]),
-        ])
+        tokenlist = TokenList(
+            [
+                Token([("id", 1), ("form", "To"), ("head", 1)]),
+                Token([("id", 2), ("form", "appear"), ("head", 2)]),
+            ]
+        )
         with self.assertRaises(ParseException):
             tokenlist.to_tree()
 
@@ -259,148 +296,196 @@ class TestSerialize(unittest.TestCase):
 
 class TestFilter(unittest.TestCase):
     def test_basic_filtering(self):
-        tokenlist = TokenList([
-            {"id": 1, "form": "a", "field": "x"},
-            {"id": 2, "form": "dog", "field": "x"},
-        ])
-        self.assertEqual(
-            tokenlist.filter(id=0),
-            TokenList([])
+        tokenlist = TokenList(
+            [
+                {"id": 1, "form": "a", "field": "x"},
+                {"id": 2, "form": "dog", "field": "x"},
+            ]
         )
+        self.assertEqual(tokenlist.filter(id=0), TokenList([]))
         self.assertEqual(
             tokenlist.filter(id=1),
-            TokenList([{"id": 1, "form": "a", "field": "x"}])
+            TokenList([{"id": 1, "form": "a", "field": "x"}]),
+        )
+        self.assertEqual(tokenlist.filter(), tokenlist)
+        self.assertEqual(tokenlist.filter(field="x"), tokenlist)
+
+    def test_metadata_propagates(self):
+        tokenlist = TokenList(
+            [
+                {"id": 1, "form": "a", "field": "x"},
+                {"id": 2, "form": "dog", "field": "x"},
+            ],
+            metadata={"text": "a dog"},
         )
         self.assertEqual(
-            tokenlist.filter(),
-            tokenlist
-        )
-        self.assertEqual(
-            tokenlist.filter(field="x"),
-            tokenlist
+            tokenlist.filter().metadata,
+            tokenlist.metadata,
         )
 
     def test_and_filtering(self):
-        tokenlist = TokenList([
-            {"id": 1, "form": "a", "field": "x"},
-            {"id": 2, "form": "dog", "field": "x"},
-            {"id": 3, "form": "dog", "field": "y"},
-        ])
+        tokenlist = TokenList(
+            [
+                {"id": 1, "form": "a", "field": "x"},
+                {"id": 2, "form": "dog", "field": "x"},
+                {"id": 3, "form": "dog", "field": "y"},
+            ]
+        )
         self.assertEqual(
             tokenlist.filter(field="x", id=2),
-            TokenList([
-                {"id": 2, "form": "dog", "field": "x"},
-            ])
+            TokenList(
+                [
+                    {"id": 2, "form": "dog", "field": "x"},
+                ]
+            ),
         )
-        self.assertEqual(
-            tokenlist.filter(field="x", id=3),
-            TokenList([])
-        )
+        self.assertEqual(tokenlist.filter(field="x", id=3), TokenList([]))
 
     def test_deep_filtering(self):
-        tokenlist = TokenList([
-            {"form": "The", "feats": Token([('Definite', 'Def'), ('PronType', 'Art')])},
-            {"form": "quick", "feats": Token([('Degree', 'Pos')])},
-            {"form": "brown", "feats": Token([('Degree', 'Pos')])},
-            {"form": "fox", "feats": Token([('Number', 'Sing')])},
-        ])
+        tokenlist = TokenList(
+            [
+                {
+                    "form": "The",
+                    "feats": Token([("Definite", "Def"), ("PronType", "Art")]),
+                },
+                {"form": "quick", "feats": Token([("Degree", "Pos")])},
+                {"form": "brown", "feats": Token([("Degree", "Pos")])},
+                {"form": "fox", "feats": Token([("Number", "Sing")])},
+            ]
+        )
         self.assertEqual(
             tokenlist.filter(feats__Degree="Pos"),
-            TokenList([
-                {"form": "quick", "feats": Token([('Degree', 'Pos')])},
-                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
-            ])
+            TokenList(
+                [
+                    {"form": "quick", "feats": Token([("Degree", "Pos")])},
+                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
+                ]
+            ),
         )
         self.assertEqual(
             tokenlist.filter(form="brown", feats__Degree="Pos"),
-            TokenList([
-                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
-            ])
+            TokenList(
+                [
+                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
+                ]
+            ),
         )
         self.assertEqual(
             tokenlist.filter(form="brown", feats__Degree="Pos", id=1),
-            TokenList([])
+            TokenList([]),
         )
         self.assertEqual(
             tokenlist.filter(unknown__property__value="undefined"),
-            TokenList([])
+            TokenList([]),
         )
         self.assertEqual(
             tokenlist.filter(unknown___property____value="undefined"),
-            TokenList([])
+            TokenList([]),
         )
 
     def test_nested_filtering(self):
-        tokenlist = TokenList([
-            {"form": "The", "feats": Token([('Definite', 'Def'), ('PronType', 'Art')])},
-            {"form": "quick", "feats": Token([('Degree', 'Pos')])},
-            {"form": "brown", "feats": Token([('Degree', 'Pos')])},
-            {"form": "fox", "feats": Token([('Number', 'Sing')])},
-        ])
+        tokenlist = TokenList(
+            [
+                {
+                    "form": "The",
+                    "feats": Token([("Definite", "Def"), ("PronType", "Art")]),
+                },
+                {"form": "quick", "feats": Token([("Degree", "Pos")])},
+                {"form": "brown", "feats": Token([("Degree", "Pos")])},
+                {"form": "fox", "feats": Token([("Number", "Sing")])},
+            ]
+        )
         self.assertEqual(
             tokenlist.filter(feats__Degree="Pos").filter(form="brown"),
-            TokenList([
-                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
-            ])
+            TokenList(
+                [
+                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
+                ]
+            ),
         )
         self.assertEqual(
             tokenlist.filter(form="brown").filter(feats__Degree="Pos"),
-            TokenList([
-                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
-            ])
+            TokenList(
+                [
+                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
+                ]
+            ),
         )
         self.assertEqual(
-            tokenlist.filter(form="brown").filter(feats__Degree="Pos").filter(),
-            TokenList([
-                {"form": "brown", "feats": Token([('Degree', 'Pos')])},
-            ])
+            tokenlist.filter(form="brown")
+            .filter(feats__Degree="Pos")
+            .filter(),
+            TokenList(
+                [
+                    {"form": "brown", "feats": Token([("Degree", "Pos")])},
+                ]
+            ),
         )
         self.assertEqual(
-            tokenlist.filter(form="brown").filter(feats__Degree="Pos").filter(id=0),
-            TokenList([])
+            tokenlist.filter(form="brown")
+            .filter(feats__Degree="Pos")
+            .filter(id=0),
+            TokenList([]),
         )
 
     def test_lambda_basic_filtering(self):
-        tokenlist = TokenList([
-            Token({'id': (1, '-', 2), 'form': "It's", 'lemma': '_', 'feats': None}),
-            Token({'id': 1, 'form': 'It', 'lemma': 'it'}),
-            Token({'id': 2, 'form': "'s", 'lemma': 'be'})
-        ])
+        tokenlist = TokenList(
+            [
+                Token(
+                    {
+                        "id": (1, "-", 2),
+                        "form": "It's",
+                        "lemma": "_",
+                        "feats": None,
+                    }
+                ),
+                Token({"id": 1, "form": "It", "lemma": "it"}),
+                Token({"id": 2, "form": "'s", "lemma": "be"}),
+            ]
+        )
 
         self.assertEqual(
             tokenlist.filter(id=lambda x: type(x) is int),
-            TokenList([
-                Token({'id': 1, 'form': 'It', 'lemma': 'it'}),
-                Token({'id': 2, 'form': "'s", 'lemma': 'be'})
-            ])
+            TokenList(
+                [
+                    Token({"id": 1, "form": "It", "lemma": "it"}),
+                    Token({"id": 2, "form": "'s", "lemma": "be"}),
+                ]
+            ),
         )
         self.assertEqual(
-            tokenlist.filter(lemma=lambda x: x.startswith('b')),
-            TokenList([
-                Token({'id': 2, 'form': "'s", 'lemma': 'be'})
-            ])
+            tokenlist.filter(lemma=lambda x: x.startswith("b")),
+            TokenList([Token({"id": 2, "form": "'s", "lemma": "be"})]),
         )
 
     def test_lambda_deep_filtering(self):
-        tokenlist = TokenList([
-            Token({'id': (1, '-', 2), 'feats': None}),
-            Token({'id': 1, 'feats': {'Case': 'Nom', 'Number': 'Sing'}}),
-            Token({'id': 2, 'feats': {'Mood': 'Ind', 'Number': 'Sing'}})
-        ])
-
-        self.assertEqual(
-            tokenlist.filter(feats__Mood=lambda x: x == 'Ind'),
-            TokenList([
-                Token({'id': 2, 'feats': {'Mood': 'Ind', 'Number': 'Sing'}})
-            ])
+        tokenlist = TokenList(
+            [
+                Token({"id": (1, "-", 2), "feats": None}),
+                Token({"id": 1, "feats": {"Case": "Nom", "Number": "Sing"}}),
+                Token({"id": 2, "feats": {"Mood": "Ind", "Number": "Sing"}}),
+            ]
         )
 
         self.assertEqual(
-            tokenlist.filter(feats__Number=lambda x: x == 'Sing'),
-            TokenList([
-                Token({'id': 1, 'feats': {'Case': 'Nom', 'Number': 'Sing'}}),
-                Token({'id': 2, 'feats': {'Mood': 'Ind', 'Number': 'Sing'}})
-            ])
+            tokenlist.filter(feats__Mood=lambda x: x == "Ind"),
+            TokenList(
+                [Token({"id": 2, "feats": {"Mood": "Ind", "Number": "Sing"}})]
+            ),
+        )
+
+        self.assertEqual(
+            tokenlist.filter(feats__Number=lambda x: x == "Sing"),
+            TokenList(
+                [
+                    Token(
+                        {"id": 1, "feats": {"Case": "Nom", "Number": "Sing"}}
+                    ),
+                    Token(
+                        {"id": 2, "feats": {"Mood": "Ind", "Number": "Sing"}}
+                    ),
+                ]
+            ),
         )
 
 
@@ -408,7 +493,9 @@ class TestTokenTree(unittest.TestCase):
     def test_eq(self):
         metadata = {"meta": "data"}
 
-        tokentree1 = TokenTree(token={"id": 1}, children=[TokenTree(token={"id": 2}, children=[])])
+        tokentree1 = TokenTree(
+            token={"id": 1}, children=[TokenTree(token={"id": 2}, children=[])]
+        )
         tokentree1.metadata = metadata
 
         tokentree2 = TokenTree(token={"id": 1}, children=[])
@@ -429,7 +516,11 @@ class TestTokenTree(unittest.TestCase):
         tree.set_metadata(metadata)
         self.assertEqual(tree.metadata, metadata)
 
-        tree = TokenTree(token={"id": 1, "form": "hej"}, children=[], metadata={"meta": "data"})
+        tree = TokenTree(
+            token={"id": 1, "form": "hej"},
+            children=[],
+            metadata={"meta": "data"},
+        )
         self.assertEqual(tree.metadata, metadata)
 
 
@@ -442,33 +533,35 @@ class TestSerializeTree(unittest.TestCase):
     def test_flatten(self):
         tree = TokenTree(
             token=Token([("id", 2), ("form", "dog")]),
-            children=[TokenTree(
-                token=Token([("id", 1), ("form", "a")]),
-                children=[]
-            )]
+            children=[
+                TokenTree(token=Token([("id", 1), ("form", "a")]), children=[])
+            ],
         )
         self.assertEqual(
             tree.serialize(),
-            dedent("""\
+            dedent(
+                """\
                 1\ta
                 2\tdog
 
-            """)
+            """
+            ),
         )
         tree = TokenTree(
             token=Token([("id", 1), ("form", "dog")]),
-            children=[TokenTree(
-                token=Token([("id", 2), ("form", "a")]),
-                children=[]
-            )]
+            children=[
+                TokenTree(token=Token([("id", 2), ("form", "a")]), children=[])
+            ],
         )
         self.assertEqual(
             tree.serialize(),
-            dedent("""\
+            dedent(
+                """\
                 1\tdog
                 2\ta
 
-            """)
+            """
+            ),
         )
 
 
@@ -489,22 +582,38 @@ class TestPrintTree(unittest.TestCase):
             capture_print(tree.print_tree)
 
     def test_print_simple(self):
-        tree = TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[])
+        tree = TokenTree(
+            token={"id": "X", "deprel": "Y", "test": "data"}, children=[]
+        )
         result = capture_print(tree.print_tree)
         self.assertEqual(result, "(deprel:Y) test:data [X]\n")
 
     def test_print_with_children(self):
-        tree = TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[
-            TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[]),
-            TokenTree(token={"id": "X", "deprel": "Y", "test": "data"}, children=[]),
-        ])
+        tree = TokenTree(
+            token={"id": "X", "deprel": "Y", "test": "data"},
+            children=[
+                TokenTree(
+                    token={"id": "X", "deprel": "Y", "test": "data"},
+                    children=[],
+                ),
+                TokenTree(
+                    token={"id": "X", "deprel": "Y", "test": "data"},
+                    children=[],
+                ),
+            ],
+        )
         result = capture_print(tree.print_tree)
 
-        self.assertEqual(result, dedent("""\
+        self.assertEqual(
+            result,
+            dedent(
+                """\
             (deprel:Y) test:data [X]
                 (deprel:Y) test:data [X]
                 (deprel:Y) test:data [X]
-        """))
+        """
+            ),
+        )
 
 
 class TestSentenceList(unittest.TestCase):
@@ -528,7 +637,9 @@ class TestSentenceList(unittest.TestCase):
         self.assertEqual(tokenlists, SentenceList(tokenlists))
 
         tokenlists2 = [TokenList([{"id": 2}])]
-        self.assertNotEqual(SentenceList(tokenlists), SentenceList(tokenlists2))
+        self.assertNotEqual(
+            SentenceList(tokenlists), SentenceList(tokenlists2)
+        )
 
     def test_clear(self):
         sentences = SentenceList([TokenList([{"id": 1}])], metadata={"a": 1})
@@ -550,8 +661,9 @@ class TestSentenceList(unittest.TestCase):
         self.assertEqual(
             sentences,
             SentenceList(
-                [TokenList([{"id": 1}]), TokenList([{"id": 2}])], metadata={"a": 1, "b": 2}
-            )
+                [TokenList([{"id": 1}]), TokenList([{"id": 2}])],
+                metadata={"a": 1, "b": 2},
+            ),
         )
 
         sentences.extend(sentences3)
@@ -559,9 +671,12 @@ class TestSentenceList(unittest.TestCase):
             sentences,
             SentenceList(
                 [
-                    TokenList([{"id": 1}]), TokenList([{"id": 2}]), TokenList([{"id": 3}])
-                ], metadata={"a": 1, "b": 2}
-            )
+                    TokenList([{"id": 1}]),
+                    TokenList([{"id": 2}]),
+                    TokenList([{"id": 3}]),
+                ],
+                metadata={"a": 1, "b": 2},
+            ),
         )
 
     def test_slicing_sentencelist_works_and_retains_metadata(self):
@@ -571,14 +686,17 @@ class TestSentenceList(unittest.TestCase):
                 TokenList([{"id": 2}]),
                 TokenList([{"id": 3}]),
             ],
-            metadata={"a": 1}
+            metadata={"a": 1},
         )
-        self.assertEqual(sentences[1:2], SentenceList(
-            [
-                TokenList([{"id": 2}]),
-            ],
-            metadata={"a": 1}
-        ))
+        self.assertEqual(
+            sentences[1:2],
+            SentenceList(
+                [
+                    TokenList([{"id": 2}]),
+                ],
+                metadata={"a": 1},
+            ),
+        )
 
     def test_slicing_with_single_int(self):
         sentences = SentenceList(
@@ -587,9 +705,10 @@ class TestSentenceList(unittest.TestCase):
                 TokenList([{"id": 2}]),
                 TokenList([{"id": 3}]),
             ],
-            metadata={"a": 1}
+            metadata={"a": 1},
         )
         self.assertEqual(sentences[1], TokenList([{"id": 2}]))
+
 
 class TestSentenceGenerator(unittest.TestCase):
     def test_init_empty_sentences_should_not_raise(self):
@@ -612,5 +731,7 @@ class TestSentenceGenerator(unittest.TestCase):
             yield tokenlist1
             yield tokenlist2
 
-        self.assertEqual(list(SentenceGenerator(two_sentences())), [tokenlist1, tokenlist2])
+        self.assertEqual(
+            list(SentenceGenerator(two_sentences())), [tokenlist1, tokenlist2]
+        )
         self.assertEqual(next(SentenceGenerator(two_sentences())), tokenlist1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+import pickle
+import tempfile
 import unittest
 from textwrap import dedent
 
@@ -286,6 +288,21 @@ class TestSerialize(unittest.TestCase):
         tokenlist = TokenList([{"id": 1}])
         self.assertEqual(tokenlist.serialize(), serialize(tokenlist))
 
+    def test_pickling_tokenlist(self):
+        tokenlist = TokenList(
+            [
+                {"id": 1, "form": "a", "field": "x"},
+                {"id": 2, "form": "dog", "field": "x"},
+            ],
+            metadata={"text": "a dog"},
+        )
+        sink = tempfile.NamedTemporaryFile("wb", suffix=".pkl", delete=False)
+        pickle.dump(tokenlist, sink)
+        sink.close()
+        with open(sink.name, "rb") as source:
+            tokenlist_copy = pickle.load(source)
+        self.assertEqual(tokenlist, tokenlist_copy)
+
 
 class TestFilter(unittest.TestCase):
     def test_basic_filtering(self):
@@ -312,8 +329,7 @@ class TestFilter(unittest.TestCase):
             metadata={"text": "a dog"},
         )
         self.assertEqual(
-            tokenlist.filter().metadata,
-            tokenlist.metadata,
+            tokenlist.filter(), tokenlist
         )
 
     def test_and_filtering(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,7 @@
 import unittest
 from textwrap import dedent
 
-from conllu.models import (
-    Metadata,
-    SentenceGenerator,
-    SentenceList,
-    Token,
-    TokenList,
-    TokenTree,
-)
+from conllu.models import Metadata, SentenceGenerator, SentenceList, Token, TokenList, TokenTree
 from conllu.parser import ParseException, serialize
 from tests.helpers import capture_print
 


### PR DESCRIPTION
I am still baffled how we are getting a `TokenList` or a `SentenceList` without this metadata in the first place, but this fixes it and adds relevant tests.

I also fixed the issue with filtering losing metadata, making the most minimal change I could. 

Closes #97.